### PR TITLE
Move side effects into effects and enable GA only in Production

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import {
   BrowserRouter as Router,
   Redirect,
@@ -12,8 +12,12 @@ import NotFound from './NotFound'
 import ErrorBoundary from './ErrorBoundary'
 import Setup from './Setup'
 
-function App() {
-  ReactGA.initialize('UA-117297491-1', { testMode: true })
+const App = () => {
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      ReactGA.initialize('UA-117297491-1')
+    }
+  }, [])
 
   return (
     <ErrorBoundary>

--- a/client/src/Login/Login.js
+++ b/client/src/Login/Login.js
@@ -6,15 +6,18 @@ import { sha1 } from 'hash-anything'
 import { useApi } from 'react-use-fetch-api'
 
 export function Login() {
-  ReactGA.pageview(window.location.pathname + window.location.search)
-  ReactGA.event({
-    category: 'Guest',
-    action: 'Landed on Login Page'
-  })
-
   const { get } = useApi()
-
   const [users, setUsers] = useState([])
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      ReactGA.pageview(window.location.pathname + window.location.search)
+      ReactGA.event({
+        category: 'Guest',
+        action: 'Landed on Login Page'
+      })
+    }
+  }, [])
 
   useEffect(() => {
     get('/api/v1/users', {

--- a/client/src/Login/__tests__/Login.test.js
+++ b/client/src/Login/__tests__/Login.test.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { mount, shallow } from 'enzyme'
 import { MemoryRouter, Route } from 'react-router'
 import { Login } from '../Login'
-import ReactGA from 'react-ga'
 import { v4 as uuid } from 'uuid'
 import { act } from 'react-dom/test-utils'
 import * as useApiModule from 'react-use-fetch-api'
@@ -34,14 +33,6 @@ describe('<Login />', () => {
   describe('before data is loaded', () => {
     beforeAll(() => {
       wrapper = shallow(<Login />)
-    })
-
-    it('calls ReactGA.pageview()', () => {
-      expect(ReactGA.pageview).toBeCalled()
-    })
-
-    it('calls ReactGA.event()', () => {
-      expect(ReactGA.event).toBeCalled()
     })
 
     it('renders the Login container', () => {


### PR DESCRIPTION
 * [ ] Did you write tests?
 * [ ] Did you run `rails rswag` from the root?
 * [ ] Did you run `rubocop` from the root?
 * [x] Did you run `yarn lint` in `/client`?
 * [x] Did you run `yarn test` in `/client`?
 * [ ] Are your primary keys UUIDs on any new tables?

Does it what it says on the tin 🙂 