### PR TITLE
Add organization to user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 on: 
   push:
+    branches:
+    - master 
+    - develop
   pull_request:
     branches:
     - master

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -53,7 +53,7 @@ class Api::V1::UsersController < Api::V1::ApiController
     params.require(:user).permit(
       :active, :email, :full_name, :greeting_name,
       :id, :language, :mobile, :opt_in_email,
-      :opt_in_phone, :opt_in_text, :phone,
+      :opt_in_phone, :opt_in_text, :organization, :phone,
       :service_agreement_accepted, :slug, :timezone
     )
   end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -42,4 +42,5 @@ end
 #
 #  index_children_on_slug     (slug) UNIQUE
 #  index_children_on_user_id  (user_id)
+#  unique_children            (first_name,last_name,date_of_birth,user_id) UNIQUE
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   validates :full_name, presence: true
   validates :language, presence: true
+  validates :organization, presence: true
   validates :opt_in_email, inclusion: { in: [true, false] }
   validates :opt_in_phone, inclusion: { in: [true, false] }
   validates :opt_in_text, inclusion: { in: [true, false] }
@@ -42,6 +43,7 @@ end
 #  opt_in_email               :boolean          default(TRUE), not null
 #  opt_in_phone               :boolean          default(TRUE), not null
 #  opt_in_text                :boolean          default(TRUE), not null
+#  organization               :string           not null
 #  phone                      :string
 #  service_agreement_accepted :boolean          default(FALSE), not null
 #  slug                       :string           not null

--- a/db/migrate/20200425210517_add_organization_to_user.rb
+++ b/db/migrate/20200425210517_add_organization_to_user.rb
@@ -1,0 +1,5 @@
+class AddOrganizationToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :organization, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_15_014152) do
+ActiveRecord::Schema.define(version: 2020_04_25_210517) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2020_04_15_014152) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "slug", null: false
+    t.string "organization", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["slug"], name: "index_users_on_slug", unique: true
   end

--- a/spec/factories/children.rb
+++ b/spec/factories/children.rb
@@ -31,4 +31,5 @@ end
 #
 #  index_children_on_slug     (slug) UNIQUE
 #  index_children_on_user_id  (user_id)
+#  unique_children            (first_name,last_name,date_of_birth,user_id) UNIQUE
 #

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     opt_in_email { Faker::Boolean.boolean }
     opt_in_phone { Faker::Boolean.boolean }
     opt_in_text { Faker::Boolean.boolean }
+    organization { Faker::Company.name }
     phone { Faker::PhoneNumber.phone_number }
     service_agreement_accepted { Faker::Boolean.boolean }
     timezone { TimeZoneService.us_zones.sample }
@@ -29,6 +30,7 @@ end
 #  opt_in_email               :boolean          default(TRUE), not null
 #  opt_in_phone               :boolean          default(TRUE), not null
 #  opt_in_text                :boolean          default(TRUE), not null
+#  organization               :string           not null
 #  phone                      :string
 #  service_agreement_accepted :boolean          default(FALSE), not null
 #  slug                       :string           not null

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -30,4 +30,5 @@ end
 #
 #  index_children_on_slug     (slug) UNIQUE
 #  index_children_on_user_id  (user_id)
+#  unique_children            (first_name,last_name,date_of_birth,user_id) UNIQUE
 #

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe User, type: :model do
   it { should validate_uniqueness_of(:email) }
   it { should validate_presence_of(:full_name) }
   it { should validate_presence_of(:language) }
+  it { should validate_presence_of(:organization) }
   it { should validate_presence_of(:timezone) }
 
   let!(:user) { create(:user, phone: '888-888-8888') }
@@ -28,6 +29,7 @@ end
 #  opt_in_email               :boolean          default(TRUE), not null
 #  opt_in_phone               :boolean          default(TRUE), not null
 #  opt_in_text                :boolean          default(TRUE), not null
+#  organization               :string           not null
 #  phone                      :string
 #  service_agreement_accepted :boolean          default(FALSE), not null
 #  slug                       :string           not null

--- a/spec/requests/api/v1/businesses_spec.rb
+++ b/spec/requests/api/v1/businesses_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'businesses API', type: :request do
       "language": 'English',
       "mobile": '912-444-5555',
       "phone": '912-444-5555',
+      "organization": 'Society for the Promotion of Elfish Welfare',
       "service_agreement_accepted": 'true',
       "timezone": 'Central Time (US & Canada)'
     }

--- a/spec/requests/api/v1/children_spec.rb
+++ b/spec/requests/api/v1/children_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'children API', type: :request do
       "language": 'English',
       "mobile": '912-444-5555',
       "phone": '912-444-5555',
+      "organization": 'Society for the Promotion of Elfish Welfare',
       "service_agreement_accepted": 'true',
       "timezone": 'Central Time (US & Canada)'
     }

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'users API', type: :request do
       "greeting_name": 'Oliver',
       "language": 'English',
       "mobile": '912-444-5555',
+      "organization": 'Society for the Promotion of Elfish Welfare',
       "phone": '912-444-5555',
       "service_agreement_accepted": 'true',
       "timezone": 'Central Time (US & Canada)'

--- a/spec/support/api/schemas/user.json
+++ b/spec/support/api/schemas/user.json
@@ -12,6 +12,7 @@
     "opt_in_email",
     "opt_in_phone",
     "opt_in_text",
+    "organization",
     "phone",
     "service_agreement_accepted",
     "slug",
@@ -19,7 +20,7 @@
     "updated_at"
   ],
   "properties": {
-    "created_at": { "type": "string" , "format": "date-time" },
+    "created_at": { "type": "string", "format": "date-time" },
     "id": { "type": "string" },
     "active": { "type": "boolean" },
     "email": { "type": "string" },
@@ -30,10 +31,11 @@
     "opt_in_email": { "type": "boolean" },
     "opt_in_phone": { "type": "boolean" },
     "opt_in_text": { "type": "boolean" },
+    "organization": { "type": "string" },
     "phone": { "type": "string" },
     "service_agreement_accepted": { "type": "boolean" },
     "slug": { "type": "string" },
     "timezone": { "type": "string" },
-    "updated_at": { "type": "string" , "format": "date-time" }
+    "updated_at": { "type": "string", "format": "date-time" }
   }
 }

--- a/spec/support/api/schemas/user_with_businesses.json
+++ b/spec/support/api/schemas/user_with_businesses.json
@@ -13,6 +13,7 @@
     "opt_in_email",
     "opt_in_phone",
     "opt_in_text",
+    "organization",
     "phone",
     "service_agreement_accepted",
     "slug",
@@ -38,16 +39,16 @@
         "properties": {
           "active": { "type": "boolean" },
           "category": { "type": "string" },
-          "created_at": { "type": "string" , "format": "date-time" },
+          "created_at": { "type": "string", "format": "date-time" },
           "id": { "type": "string" },
           "name": { "type": "string" },
           "slug": { "type": "string" },
-          "updated_at": { "type": "string" , "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" },
           "user_id": { "type": "string", "format": "uuid" }
         }
       }
     },
-    "created_at": { "type": "string" , "format": "date-time" },
+    "created_at": { "type": "string", "format": "date-time" },
     "email": { "type": "string" },
     "full_name": { "type": "string" },
     "greeting_name": { "type": "string" },
@@ -57,10 +58,11 @@
     "opt_in_email": { "type": "boolean" },
     "opt_in_phone": { "type": "boolean" },
     "opt_in_text": { "type": "boolean" },
+    "organization": { "type": "string" },
     "phone": { "type": "string" },
     "service_agreement_accepted": { "type": "boolean" },
     "slug": { "type": "string" },
     "timezone": { "type": "string" },
-    "updated_at": { "type": "string" , "format": "date-time" }
+    "updated_at": { "type": "string", "format": "date-time" }
   }
 }

--- a/spec/support/api/schemas/user_with_children.json
+++ b/spec/support/api/schemas/user_with_children.json
@@ -13,6 +13,7 @@
     "opt_in_email",
     "opt_in_phone",
     "opt_in_text",
+    "organization",
     "phone",
     "service_agreement_accepted",
     "slug",
@@ -41,19 +42,19 @@
         "properties": {
           "active": { "type": "boolean" },
           "ccms_id": { "type": "string" },
-          "created_at": { "type": "string" , "format": "date-time" },
+          "created_at": { "type": "string", "format": "date-time" },
           "date_of_birth": { "type": "string", "format": "date" },
           "id": { "type": "string" },
           "first_name": { "type": "string" },
           "full_name": { "type": "string" },
           "last_name": { "type": "string" },
           "slug": { "type": "string" },
-          "updated_at": { "type": "string" , "format": "date-time" },
+          "updated_at": { "type": "string", "format": "date-time" },
           "user_id": { "type": "string", "format": "uuid" }
         }
       }
     },
-    "created_at": { "type": "string" , "format": "date-time" },
+    "created_at": { "type": "string", "format": "date-time" },
     "email": { "type": "string" },
     "full_name": { "type": "string" },
     "greeting_name": { "type": "string" },
@@ -63,10 +64,11 @@
     "opt_in_email": { "type": "boolean" },
     "opt_in_phone": { "type": "boolean" },
     "opt_in_text": { "type": "boolean" },
+    "organization": { "type": "string" },
     "phone": { "type": "string" },
     "service_agreement_accepted": { "type": "boolean" },
     "slug": { "type": "string" },
     "timezone": { "type": "string" },
-    "updated_at": { "type": "string" , "format": "date-time" }
+    "updated_at": { "type": "string", "format": "date-time" }
   }
 }

--- a/spec/support/api/schemas/users.json
+++ b/spec/support/api/schemas/users.json
@@ -15,6 +15,7 @@
       "opt_in_email",
       "opt_in_phone",
       "opt_in_text",
+      "organization",
       "phone",
       "service_agreement_accepted",
       "slug",
@@ -22,7 +23,7 @@
       "updated_at"
     ],
     "properties": {
-      "created_at": { "type": "string" , "format": "date-time" },
+      "created_at": { "type": "string", "format": "date-time" },
       "id": { "type": "string" },
       "active": { "type": "boolean" },
       "email": { "type": "string" },
@@ -33,11 +34,12 @@
       "opt_in_email": { "type": "boolean" },
       "opt_in_phone": { "type": "boolean" },
       "opt_in_text": { "type": "boolean" },
+      "organization": { "type": "string" },
       "phone": { "type": "string" },
       "service_agreement_accepted": { "type": "boolean" },
       "slug": { "type": "string" },
       "timezone": { "type": "string" },
-      "updated_at": { "type": "string" , "format": "date-time" }
+      "updated_at": { "type": "string", "format": "date-time" }
     }
   }
 }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -85,11 +85,11 @@ RSpec.configure do |config|
             properties: {
               name: { type: :string, example: 'Harlequin Childcare' },
               category: { type: :string, example: 'license_exempt_home' },
-              user_id: { type: :uuid, example: '3fa57706-f5bb-4d40-9350-85871f698d55'}
+              user_id: { type: :uuid, example: '3fa57706-f5bb-4d40-9350-85871f698d55' }
             },
             required: %w[
               name
-              category,
+              category
               user_id
             ]
           }
@@ -119,7 +119,7 @@ RSpec.configure do |config|
               first_name: { type: :string, example: 'Seamus' },
               full_name: { type: :string, example: 'Seamus Finnigan' },
               last_name: { type: :string, example: 'Finnigan' },
-              user_id: { type: :uuid, example: '3fa57706-f5bb-4d40-9350-85871f698d55'}
+              user_id: { type: :uuid, example: '3fa57706-f5bb-4d40-9350-85871f698d55' }
             },
             required: %w[
               first_name

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -43,6 +43,7 @@ RSpec.configure do |config|
                 full_name: { type: :string, example: 'Marlee Matlin' },
                 greeting_name: { type: :string, example: 'Marlee' },
                 language: { type: :string, example: 'Farsi' },
+                organization: { type: :string, example: 'Society for the Promotion of Elfish Welfare' },
                 phone: { type: :string, example: '888-888-8888' },
                 service_agreement_accepted: { type: :boolean, example: 'true' },
                 timezone: { type: :string, example: 'Eastern Time (US & Canada)' }
@@ -67,6 +68,7 @@ RSpec.configure do |config|
                 full_name: { type: :string, example: 'Marlee Matlin' },
                 greeting_name: { type: :string, example: 'Marlee' },
                 language: { type: :string, example: 'Farsi' },
+                organization: { type: :string, example: 'Society for the Promotion of Elfish Welfare' },
                 phone: { type: :string, example: '888-888-8888' },
                 service_agreement_accepted: { type: :boolean, example: 'true' },
                 timezone: { type: :string, example: 'Eastern Time (US & Canada)' }
@@ -82,11 +84,13 @@ RSpec.configure do |config|
             type: :object,
             properties: {
               name: { type: :string, example: 'Harlequin Childcare' },
-              category: { type: :string, example: 'license_exempt_home' }
+              category: { type: :string, example: 'license_exempt_home' },
+              user_id: { type: :uuid, example: '3fa57706-f5bb-4d40-9350-85871f698d55'}
             },
             required: %w[
               name
-              category
+              category,
+              user_id
             ]
           }
         }
@@ -114,12 +118,14 @@ RSpec.configure do |config|
               date_of_birth: { type: :string, example: '1991-11-01' },
               first_name: { type: :string, example: 'Seamus' },
               full_name: { type: :string, example: 'Seamus Finnigan' },
-              last_name: { type: :string, example: 'Finnigan' }
+              last_name: { type: :string, example: 'Finnigan' },
+              user_id: { type: :uuid, example: '3fa57706-f5bb-4d40-9350-85871f698d55'}
             },
             required: %w[
               first_name
               last_name
               date_of_birth
+              user_id
             ]
           }
         }

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -551,6 +551,10 @@
               "type": "string",
               "example": "Farsi"
             },
+            "organization": {
+              "type": "string",
+              "example": "Society for the Promotion of Elfish Welfare"
+            },
             "phone": {
               "type": "string",
               "example": "888-888-8888"
@@ -596,6 +600,10 @@
               "type": "string",
               "example": "Farsi"
             },
+            "organization": {
+              "type": "string",
+              "example": "Society for the Promotion of Elfish Welfare"
+            },
             "phone": {
               "type": "string",
               "example": "888-888-8888"
@@ -626,11 +634,16 @@
           "category": {
             "type": "string",
             "example": "license_exempt_home"
+          },
+          "user_id": {
+            "type": "uuid",
+            "example": "3fa57706-f5bb-4d40-9350-85871f698d55"
           }
         },
         "required": [
           "name",
-          "category"
+          "category,",
+          "user_id"
         ]
       }
     }
@@ -682,12 +695,17 @@
           "last_name": {
             "type": "string",
             "example": "Finnigan"
+          },
+          "user_id": {
+            "type": "uuid",
+            "example": "3fa57706-f5bb-4d40-9350-85871f698d55"
           }
         },
         "required": [
           "first_name",
           "last_name",
-          "date_of_birth"
+          "date_of_birth",
+          "user_id"
         ]
       }
     }


### PR DESCRIPTION
Fixes #78 

# Before You Submit:
 * [X] Did you write tests?
 * [X] Did you run `rails rswag` from the root?
 * [X] Did you run `rubocop` from the root?
 * [ ] Did you run `yarn lint` in `/client`?
 * [ ] Did you run `yarn test` in `/client`?
 * [ ] Are your primary keys UUIDs on any new tables?

## Deployment Considerations
* [ ] Data Migrations
* [X] Schema Migrations
* [ ] Dependencies

## 📋 Summary
Adds an organization field to the User table

## 🧐 Why tho
The user should be able to name the organization they work for, since it might be different from the businesses they are overseeing.

## 💻 Steps to set up locally
`rails db:migrate:with_data`

## ✅ Steps to test
Organization should now be required on the User create endpoint; also organization was added to the user_with_children and user_with_businesses json response definitions (though we don't have an endpoint for those currently)

## 🤔 Caveats, concerns
None!
