### PR TITLE
Removes first and last name from children table

### DIFF
--- a/app/controllers/api/v1/children_controller.rb
+++ b/app/controllers/api/v1/children_controller.rb
@@ -50,7 +50,7 @@ class Api::V1::ChildrenController < Api::V1::ApiController
 
   def child_params
     params.require(:child).permit(
-      :active, :ccms_id, :date_of_birth, :first_name, :full_name, :id, :last_name, :slug, :user_id
+      :active, :ccms_id, :date_of_birth, :full_name, :id, :slug, :user_id
     )
   end
 end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -9,8 +9,6 @@ class Child < ApplicationRecord
 
   validates :active, inclusion: { in: [true, false] }
   validates :date_of_birth, presence: true
-  validates :first_name, presence: true
-  validates :last_name, presence: true
   validates :full_name, presence: true
 
   validates_each :date_of_birth do |record, attr, value|
@@ -19,7 +17,7 @@ class Child < ApplicationRecord
     record.errors.add(attr, 'Invalid date')
   end
 
-  before_validation { |child| child.slug = generate_slug("#{child.first_name}#{child.last_name}#{child.date_of_birth}#{child.user_id}") }
+  before_validation { |child| child.slug = generate_slug("#{child.full_name}#{child.date_of_birth}#{child.user_id}") }
 end
 
 # == Schema Information
@@ -29,9 +27,7 @@ end
 #  id            :uuid             not null, primary key
 #  active        :boolean          default(TRUE), not null
 #  date_of_birth :date             not null
-#  first_name    :string           not null
 #  full_name     :string           not null
-#  last_name     :string           not null
 #  slug          :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -42,5 +38,5 @@ end
 #
 #  index_children_on_slug     (slug) UNIQUE
 #  index_children_on_user_id  (user_id)
-#  unique_children            (first_name,last_name,date_of_birth,user_id) UNIQUE
+#  unique_children            (full_name,date_of_birth,user_id) UNIQUE
 #

--- a/db/migrate/20200426002926_remove_first_and_last_name_from_children.rb
+++ b/db/migrate/20200426002926_remove_first_and_last_name_from_children.rb
@@ -1,0 +1,8 @@
+class RemoveFirstAndLastNameFromChildren < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :children, column: [:first_name, :last_name, :date_of_birth, :user_id], unique: true, name: :unique_children
+    add_index :children, [:full_name, :date_of_birth, :user_id], unique: true, name: :unique_children
+    remove_column :children, :first_name, :string
+    remove_column :children, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_25_220142) do
+ActiveRecord::Schema.define(version: 2020_04_26_002926) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -32,15 +32,13 @@ ActiveRecord::Schema.define(version: 2020_04_25_220142) do
   create_table "children", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.string "ccms_id"
-    t.string "first_name", null: false
-    t.string "last_name", null: false
     t.string "full_name", null: false
     t.date "date_of_birth", null: false
     t.uuid "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "slug", null: false
-    t.index ["first_name", "last_name", "date_of_birth", "user_id"], name: "unique_children", unique: true
+    t.index ["full_name", "date_of_birth", "user_id"], name: "unique_children", unique: true
     t.index ["slug"], name: "index_children_on_slug", unique: true
     t.index ["user_id"], name: "index_children_on_user_id"
   end

--- a/spec/factories/children.rb
+++ b/spec/factories/children.rb
@@ -4,9 +4,7 @@ FactoryBot.define do
   factory :child do
     ccms_id { Faker::Number.number(digits: 10) }
     date_of_birth { Faker::Date.birthday(min_age: 18, max_age: 65).strftime('%Y-%m-%d') }
-    first_name { Faker::Name.first_name }
     full_name { Faker::Name.name }
-    last_name { Faker::Name.last_name }
     user
   end
 end
@@ -18,9 +16,7 @@ end
 #  id            :uuid             not null, primary key
 #  active        :boolean          default(TRUE), not null
 #  date_of_birth :date             not null
-#  first_name    :string           not null
 #  full_name     :string           not null
-#  last_name     :string           not null
 #  slug          :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -31,5 +27,5 @@ end
 #
 #  index_children_on_slug     (slug) UNIQUE
 #  index_children_on_user_id  (user_id)
-#  unique_children            (first_name,last_name,date_of_birth,user_id) UNIQUE
+#  unique_children            (full_name,date_of_birth,user_id) UNIQUE
 #

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -4,9 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Child, type: :model do
   it { should belong_to(:user) }
-  it { should validate_presence_of(:first_name) }
   it { should validate_presence_of(:full_name) }
-  it { should validate_presence_of(:last_name) }
   it { should validate_presence_of(:date_of_birth) }
 end
 
@@ -17,9 +15,7 @@ end
 #  id            :uuid             not null, primary key
 #  active        :boolean          default(TRUE), not null
 #  date_of_birth :date             not null
-#  first_name    :string           not null
 #  full_name     :string           not null
-#  last_name     :string           not null
 #  slug          :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -30,5 +26,5 @@ end
 #
 #  index_children_on_slug     (slug) UNIQUE
 #  index_children_on_user_id  (user_id)
-#  unique_children            (first_name,last_name,date_of_birth,user_id) UNIQUE
+#  unique_children            (full_name,date_of_birth,user_id) UNIQUE
 #

--- a/spec/requests/api/v1/children_spec.rb
+++ b/spec/requests/api/v1/children_spec.rb
@@ -20,9 +20,7 @@ RSpec.describe 'children API', type: :request do
   let!(:child_params) do
     {
       "ccms_id": '1234567890',
-      "first_name": 'Parvati',
       "full_name": 'Parvati Patil',
-      "last_name": 'Patil',
       "date_of_birth": '1981-04-09',
       "user_id": user_id
     }
@@ -200,15 +198,15 @@ RSpec.describe 'children API', type: :request do
         # context 'when authenticated' do
         #   include_context 'authenticated user'
         response '200', 'child updated' do
-          let(:child) { { "child": child_params.merge("first_name": 'Padma') } }
+          let(:child) { { "child": child_params.merge("full_name": 'Padma Patil') } }
           run_test! do
             expect(response).to match_response_schema('child')
-            expect(response.parsed_body['first_name']).to eq('Padma')
+            expect(response.parsed_body['full_name']).to eq('Padma Patil')
           end
         end
 
         response '422', 'child cannot be updated' do
-          let(:child) { { "child": { "first_name": nil } } }
+          let(:child) { { "child": { "full_name": nil } } }
           run_test!
         end
 

--- a/spec/support/api/schemas/child.json
+++ b/spec/support/api/schemas/child.json
@@ -5,10 +5,8 @@
     "ccms_id",
     "created_at",
     "date_of_birth",
-    "first_name",
     "full_name",
     "id",
-    "last_name",
     "slug",
     "updated_at",
     "user_id"
@@ -16,14 +14,12 @@
   "properties": {
     "active": { "type": "boolean" },
     "ccms_id": { "type": "string" },
-    "created_at": { "type": "string" , "format": "date-time" },
+    "created_at": { "type": "string", "format": "date-time" },
     "date_of_birth": { "type": "string", "format": "date" },
     "id": { "type": "string" },
-    "first_name": { "type": "string" },
     "full_name": { "type": "string" },
-    "last_name": { "type": "string" },
     "slug": { "type": "string" },
-    "updated_at": { "type": "string" , "format": "date-time" },
+    "updated_at": { "type": "string", "format": "date-time" },
     "user_id": { "type": "string", "format": "uuid" }
   }
 }

--- a/spec/support/api/schemas/children.json
+++ b/spec/support/api/schemas/children.json
@@ -8,10 +8,8 @@
       "ccms_id",
       "created_at",
       "date_of_birth",
-      "first_name",
       "full_name",
       "id",
-      "last_name",
       "slug",
       "updated_at",
       "user_id"
@@ -19,14 +17,12 @@
     "properties": {
       "active": { "type": "boolean" },
       "ccms_id": { "type": "string" },
-      "created_at": { "type": "string" , "format": "date-time" },
+      "created_at": { "type": "string", "format": "date-time" },
       "date_of_birth": { "type": "string", "format": "date" },
       "id": { "type": "string" },
-      "first_name": { "type": "string" },
       "full_name": { "type": "string" },
-      "last_name": { "type": "string" },
       "slug": { "type": "string" },
-      "updated_at": { "type": "string" , "format": "date-time" },
+      "updated_at": { "type": "string", "format": "date-time" },
       "user_id": { "type": "string", "format": "uuid" }
     }
   }

--- a/spec/support/api/schemas/user_with_children.json
+++ b/spec/support/api/schemas/user_with_children.json
@@ -31,10 +31,8 @@
           "ccms_id",
           "created_at",
           "date_of_birth",
-          "first_name",
           "full_name",
           "id",
-          "last_name",
           "slug",
           "updated_at",
           "user_id"
@@ -45,9 +43,7 @@
           "created_at": { "type": "string", "format": "date-time" },
           "date_of_birth": { "type": "string", "format": "date" },
           "id": { "type": "string" },
-          "first_name": { "type": "string" },
           "full_name": { "type": "string" },
-          "last_name": { "type": "string" },
           "slug": { "type": "string" },
           "updated_at": { "type": "string", "format": "date-time" },
           "user_id": { "type": "string", "format": "uuid" }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -116,14 +116,11 @@ RSpec.configure do |config|
             properties: {
               ccms_id: { type: :string, example: '123456789' },
               date_of_birth: { type: :string, example: '1991-11-01' },
-              first_name: { type: :string, example: 'Seamus' },
               full_name: { type: :string, example: 'Seamus Finnigan' },
-              last_name: { type: :string, example: 'Finnigan' },
               user_id: { type: :uuid, example: '3fa57706-f5bb-4d40-9350-85871f698d55' }
             },
             required: %w[
-              first_name
-              last_name
+              full_name
               date_of_birth
               user_id
             ]
@@ -138,9 +135,7 @@ RSpec.configure do |config|
             properties: {
               ccms_id: { type: :string, example: '987654321' },
               date_of_birth: { type: :string, example: '1992-11-01' },
-              first_name: { type: :string, example: 'Sean' },
-              full_name: { type: :string, example: 'Sean Flannery' },
-              last_name: { type: :string, example: 'Flannery' }
+              full_name: { type: :string, example: 'Sean Flannery' }
             }
           }
         }

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -8,12 +8,8 @@
     "/api/v1/businesses": {
       "get": {
         "summary": "lists all businesses for a user",
-        "tags": [
-          "businesses"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        "tags": ["businesses"],
+        "produces": ["application/json"],
         "parameters": [
           {
             "name": "Accept",
@@ -33,13 +29,8 @@
       },
       "post": {
         "summary": "creates a business",
-        "tags": [
-          "businesses"
-        ],
-        "consumes": [
-          "application/json",
-          "application/xml"
-        ],
+        "tags": ["businesses"],
+        "consumes": ["application/json", "application/xml"],
         "parameters": [
           {
             "name": "Accept",
@@ -79,13 +70,8 @@
       ],
       "get": {
         "summary": "retrieves a business",
-        "tags": [
-          "businesses"
-        ],
-        "produces": [
-          "application/json",
-          "application/xml"
-        ],
+        "tags": ["businesses"],
+        "produces": ["application/json", "application/xml"],
         "parameters": [
           {
             "name": "Accept",
@@ -108,17 +94,9 @@
       },
       "put": {
         "summary": "updates a business",
-        "tags": [
-          "businesses"
-        ],
-        "consumes": [
-          "application/json",
-          "application/xml"
-        ],
-        "produces": [
-          "application/json",
-          "application/xml"
-        ],
+        "tags": ["businesses"],
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/json", "application/xml"],
         "parameters": [
           {
             "name": "Accept",
@@ -151,13 +129,8 @@
       },
       "delete": {
         "summary": "deletes a business",
-        "tags": [
-          "businesses"
-        ],
-        "produces": [
-          "application/json",
-          "application/xml"
-        ],
+        "tags": ["businesses"],
+        "produces": ["application/json", "application/xml"],
         "parameters": [
           {
             "name": "Accept",
@@ -182,12 +155,8 @@
     "/api/v1/children": {
       "get": {
         "summary": "lists all children",
-        "tags": [
-          "children"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        "tags": ["children"],
+        "produces": ["application/json"],
         "parameters": [
           {
             "name": "Accept",
@@ -207,13 +176,8 @@
       },
       "post": {
         "summary": "creates a child",
-        "tags": [
-          "children"
-        ],
-        "consumes": [
-          "application/json",
-          "application/xml"
-        ],
+        "tags": ["children"],
+        "consumes": ["application/json", "application/xml"],
         "parameters": [
           {
             "name": "Accept",
@@ -253,13 +217,8 @@
       ],
       "get": {
         "summary": "retrieves a child",
-        "tags": [
-          "children"
-        ],
-        "produces": [
-          "application/json",
-          "application/xml"
-        ],
+        "tags": ["children"],
+        "produces": ["application/json", "application/xml"],
         "parameters": [
           {
             "name": "Accept",
@@ -282,17 +241,9 @@
       },
       "put": {
         "summary": "updates a child",
-        "tags": [
-          "children"
-        ],
-        "consumes": [
-          "application/json",
-          "application/xml"
-        ],
-        "produces": [
-          "application/json",
-          "application/xml"
-        ],
+        "tags": ["children"],
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/json", "application/xml"],
         "parameters": [
           {
             "name": "Accept",
@@ -325,13 +276,8 @@
       },
       "delete": {
         "summary": "deletes a child",
-        "tags": [
-          "children"
-        ],
-        "produces": [
-          "application/json",
-          "application/xml"
-        ],
+        "tags": ["children"],
+        "produces": ["application/json", "application/xml"],
         "parameters": [
           {
             "name": "Accept",
@@ -356,12 +302,8 @@
     "/api/v1/users": {
       "get": {
         "summary": "lists all users",
-        "tags": [
-          "users"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        "tags": ["users"],
+        "produces": ["application/json"],
         "parameters": [
           {
             "name": "Accept",
@@ -381,13 +323,8 @@
       },
       "post": {
         "summary": "creates a user",
-        "tags": [
-          "users"
-        ],
-        "consumes": [
-          "application/json",
-          "application/xml"
-        ],
+        "tags": ["users"],
+        "consumes": ["application/json", "application/xml"],
         "parameters": [
           {
             "name": "Accept",
@@ -427,13 +364,8 @@
       ],
       "get": {
         "summary": "retrieves a user",
-        "tags": [
-          "users"
-        ],
-        "produces": [
-          "application/json",
-          "application/xml"
-        ],
+        "tags": ["users"],
+        "produces": ["application/json", "application/xml"],
         "parameters": [
           {
             "name": "Accept",
@@ -456,17 +388,9 @@
       },
       "put": {
         "summary": "updates a user",
-        "tags": [
-          "users"
-        ],
-        "consumes": [
-          "application/json",
-          "application/xml"
-        ],
-        "produces": [
-          "application/json",
-          "application/xml"
-        ],
+        "tags": ["users"],
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/json", "application/xml"],
         "parameters": [
           {
             "name": "Accept",
@@ -499,13 +423,8 @@
       },
       "delete": {
         "summary": "deletes a user",
-        "tags": [
-          "users"
-        ],
-        "produces": [
-          "application/json",
-          "application/xml"
-        ],
+        "tags": ["users"],
+        "produces": ["application/json", "application/xml"],
         "parameters": [
           {
             "name": "Accept",
@@ -640,11 +559,7 @@
             "example": "3fa57706-f5bb-4d40-9350-85871f698d55"
           }
         },
-        "required": [
-          "name",
-          "category,",
-          "user_id"
-        ]
+        "required": ["name", "category,", "user_id"]
       }
     }
   },
@@ -684,29 +599,16 @@
             "type": "string",
             "example": "1991-11-01"
           },
-          "first_name": {
-            "type": "string",
-            "example": "Seamus"
-          },
           "full_name": {
             "type": "string",
             "example": "Seamus Finnigan"
-          },
-          "last_name": {
-            "type": "string",
-            "example": "Finnigan"
           },
           "user_id": {
             "type": "uuid",
             "example": "3fa57706-f5bb-4d40-9350-85871f698d55"
           }
         },
-        "required": [
-          "first_name",
-          "last_name",
-          "date_of_birth",
-          "user_id"
-        ]
+        "required": ["full_name", "date_of_birth", "user_id"]
       }
     }
   },
@@ -724,17 +626,9 @@
             "type": "string",
             "example": "1992-11-01"
           },
-          "first_name": {
-            "type": "string",
-            "example": "Sean"
-          },
           "full_name": {
             "type": "string",
             "example": "Sean Flannery"
-          },
-          "last_name": {
-            "type": "string",
-            "example": "Flannery"
           }
         }
       }

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -8,8 +8,12 @@
     "/api/v1/businesses": {
       "get": {
         "summary": "lists all businesses for a user",
-        "tags": ["businesses"],
-        "produces": ["application/json"],
+        "tags": [
+          "businesses"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -29,8 +33,13 @@
       },
       "post": {
         "summary": "creates a business",
-        "tags": ["businesses"],
-        "consumes": ["application/json", "application/xml"],
+        "tags": [
+          "businesses"
+        ],
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -70,8 +79,13 @@
       ],
       "get": {
         "summary": "retrieves a business",
-        "tags": ["businesses"],
-        "produces": ["application/json", "application/xml"],
+        "tags": [
+          "businesses"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -94,9 +108,17 @@
       },
       "put": {
         "summary": "updates a business",
-        "tags": ["businesses"],
-        "consumes": ["application/json", "application/xml"],
-        "produces": ["application/json", "application/xml"],
+        "tags": [
+          "businesses"
+        ],
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -129,8 +151,13 @@
       },
       "delete": {
         "summary": "deletes a business",
-        "tags": ["businesses"],
-        "produces": ["application/json", "application/xml"],
+        "tags": [
+          "businesses"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -155,8 +182,12 @@
     "/api/v1/children": {
       "get": {
         "summary": "lists all children",
-        "tags": ["children"],
-        "produces": ["application/json"],
+        "tags": [
+          "children"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -176,8 +207,13 @@
       },
       "post": {
         "summary": "creates a child",
-        "tags": ["children"],
-        "consumes": ["application/json", "application/xml"],
+        "tags": [
+          "children"
+        ],
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -217,8 +253,13 @@
       ],
       "get": {
         "summary": "retrieves a child",
-        "tags": ["children"],
-        "produces": ["application/json", "application/xml"],
+        "tags": [
+          "children"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -241,9 +282,17 @@
       },
       "put": {
         "summary": "updates a child",
-        "tags": ["children"],
-        "consumes": ["application/json", "application/xml"],
-        "produces": ["application/json", "application/xml"],
+        "tags": [
+          "children"
+        ],
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -276,8 +325,13 @@
       },
       "delete": {
         "summary": "deletes a child",
-        "tags": ["children"],
-        "produces": ["application/json", "application/xml"],
+        "tags": [
+          "children"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -302,8 +356,12 @@
     "/api/v1/users": {
       "get": {
         "summary": "lists all users",
-        "tags": ["users"],
-        "produces": ["application/json"],
+        "tags": [
+          "users"
+        ],
+        "produces": [
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -323,8 +381,13 @@
       },
       "post": {
         "summary": "creates a user",
-        "tags": ["users"],
-        "consumes": ["application/json", "application/xml"],
+        "tags": [
+          "users"
+        ],
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -364,8 +427,13 @@
       ],
       "get": {
         "summary": "retrieves a user",
-        "tags": ["users"],
-        "produces": ["application/json", "application/xml"],
+        "tags": [
+          "users"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -388,9 +456,17 @@
       },
       "put": {
         "summary": "updates a user",
-        "tags": ["users"],
-        "consumes": ["application/json", "application/xml"],
-        "produces": ["application/json", "application/xml"],
+        "tags": [
+          "users"
+        ],
+        "consumes": [
+          "application/json",
+          "application/xml"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -423,8 +499,13 @@
       },
       "delete": {
         "summary": "deletes a user",
-        "tags": ["users"],
-        "produces": ["application/json", "application/xml"],
+        "tags": [
+          "users"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
         "parameters": [
           {
             "name": "Accept",
@@ -559,7 +640,11 @@
             "example": "3fa57706-f5bb-4d40-9350-85871f698d55"
           }
         },
-        "required": ["name", "category,", "user_id"]
+        "required": [
+          "name",
+          "category",
+          "user_id"
+        ]
       }
     }
   },
@@ -608,7 +693,11 @@
             "example": "3fa57706-f5bb-4d40-9350-85871f698d55"
           }
         },
-        "required": ["full_name", "date_of_birth", "user_id"]
+        "required": [
+          "full_name",
+          "date_of_birth",
+          "user_id"
+        ]
       }
     }
   },


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
Fixes #51 - removes the first and last name columns from the children table; we're going to take in first and last name and save it as full_name.  The intention is never to update CCMS info from our API; instead we'll be associated to children via ccms_id and pass data from Pie that is unique (regarding subsidy status, etc).  We want to be inclusive; some folks don't have a first and a last name.

# 🍂 Before You Submit:
<!-- Check steps as necessary - this list is a reminder -->
 * [X] Did you write tests?
 * [X] Did you run `rails rswag` from the root?
 * [X] Did you run `rubocop` from the root?
 * [ ] Did you run `yarn lint` in `/client`?
 * [ ] Did you run `yarn test` in `/client`?
 * [ ] Are your primary keys UUIDs on any new tables?

# 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [X] Schema Migrations
* [ ] Dependencies

# 🧵 Steps to set up locally
```
rails db:migrate:with_data
```

# 🧳 Steps to test
- Make sure API requests with no first_name or last_name still pass.
- Make sure API requests with first_name and last_name still pass; they should just ignore those fields.