### PR TITLE
Responsive Signup media

### DIFF
--- a/client/src/_assets/styles/layouts/signup.css
+++ b/client/src/_assets/styles/layouts/signup.css
@@ -27,7 +27,6 @@
 }
 
 @media (min-width: 768px) {
-  
   #layout-signup .right form {
     display: grid;
     grid-template-columns: repeat(8, 1fr);
@@ -53,8 +52,8 @@
     display: block;
     background-image: url(../../kid1.png);
     background-repeat: no-repeat;
-    background-size: auto auto;
-    background-attachment: fixed;
+    background-size: 100%;
+    background-attachment: local;
   }
 
   #layout-signup .right {
@@ -69,7 +68,6 @@
     grid-template-columns: 1fr 1fr;
   }
 
-  
   #layout-signup .right form > div > label,
   #layout-signup .right form > fieldset > legend {
     grid-column: 1 / -1;
@@ -91,10 +89,9 @@
     grid-column: 1 / 2;
   }
 
-  #layout-signup .right form > .medium\:text-center, 
+  #layout-signup .right form > .medium\:text-center,
   #layout-signup .right form > .medium\:text-center > div {
     /* display: block; */
     grid-column: 1 / -1;
   }
-
 }


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
Fixes [125](https://github.com/pieforproviders/pieforproviders/issues/125) Image was fixed and set to width/length auto which meant that for larger screens, the element would contain white space once the width of the image had been fulfilled. Image is now always set to 100% width and with a local background-attachment which means that it will scroll and resize on width depending on the screen size.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
_No, no tests were written before as this was a css change, but I'd be happy to do so!_
* [x] Did you run `rails rswag` from the root?
* [x] Did you run `rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?
_Not necessary_

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies
_None of the above_

## 🧵 Steps to set up locally
Run locally, show on many screens
<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
From my 13 inch Macbook:
<img width="1440" alt="Screen Shot 2020-06-30 at 7 44 32 PM" src="https://user-images.githubusercontent.com/31748798/86190993-86462600-bb0b-11ea-9010-b2500cca5b1d.png">

From my larger (how many inches?) display:
![Screen Shot 2020-06-30 at 7 43 27 PM 2](https://user-images.githubusercontent.com/31748798/86190995-880fe980-bb0b-11ea-805b-dc2e82b4a78c.png)




