### PR TITLE
shortened space between label and form

### DIFF
--- a/client/src/Signup/Signup.js
+++ b/client/src/Signup/Signup.js
@@ -190,7 +190,7 @@ export function Signup() {
           <div className="phone-input mb-4">
             <label
               htmlFor="phoneType"
-              className="block mb-4"
+              className="block mb-2"
               id="phone-type-label"
             >
               Phone number (we will only call or text if you want us to)


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
Fixes [131](https://github.com/pieforproviders/pieforproviders/issues/131) Was mb-4 distance between phone number label and form but now its mb-2. Ta-da!

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you run `rails rswag` from the root?
* [x] Did you run `rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?

![image](https://user-images.githubusercontent.com/31748798/86193544-c6a8a280-bb11-11ea-9d77-eaf702a38f24.png)
