### PR TITLE
#168: Add an abstract class for all ActiveRecords using UUID so ordering is correct for all

### DIFF
--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # The businesses for which users are responsible for keeping subsidy data
-class Business < ApplicationRecord
+class Business < UuidApplicationRecord
   CATEGORIES = %w[
     licensed_center_single
     licensed_center_multi
@@ -11,9 +11,6 @@ class Business < ApplicationRecord
     license_exempt_center_single
     license_exempt_center_multi
   ].freeze
-
-  # Handles UUIDs breaking ActiveRecord's usual ".first" and ".last" behavior
-  self.implicit_order_column = 'created_at'
 
   belongs_to :user
 

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -2,7 +2,6 @@
 
 # A child in care at businesses who need subsidy assistance
 class Child < UuidApplicationRecord
-
   belongs_to :user
 
   validates :active, inclusion: { in: [true, false] }

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 # A child in care at businesses who need subsidy assistance
-class Child < ApplicationRecord
-  # Handles UUIDs breaking ActiveRecord's usual ".first" and ".last" behavior
-  self.implicit_order_column = 'created_at'
+class Child < UuidApplicationRecord
 
   belongs_to :user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
 # Person responsible for subsidy management for one or more businesses
-class User < ApplicationRecord
+class User < UuidApplicationRecord
   # Include default devise modules. Others available are:
   # :lockable, :omniauthable, :rememberable, :timeoutable, :trackable
   devise :confirmable, :database_authenticatable, :registerable,
          :recoverable, :validatable, :jwt_authenticatable,
          jwt_revocation_strategy: BlockedToken
-
-  # Handles UUIDs breaking ActiveRecord's usual ".first" and ".last" behavior
-  self.implicit_order_column = 'created_at'
 
   has_many :businesses, dependent: :restrict_with_error
   has_many :children, dependent: :restrict_with_error

--- a/app/models/uuid_application_record.rb
+++ b/app/models/uuid_application_record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Superclass for all ActiveRecords using UUIDs.
+# Fix so ActiveRecord's usual ".first" and ".last" behavior works with UUIDs.
+class UuidApplicationRecord < ApplicationRecord
+  self.abstract_class = true
+
+  self.implicit_order_column = 'created_at'
+end


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->
#168 Parent abstract class for ActiveRecord models with UUID 'created_on' 
1. Added `class UuidApplicationRecord < ApplicationRecord` 
   It has the common bit of code that all AR models using UUID need so that ordering (.first, .last) works properly.
2. Changed existing ActiveRecord models to inherit from this new class and removed the duplicated code.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests? n/a
* [ ] Did you run `rails rswag` from the root? n/a
* [ ] Did you run `rubocop` from the root? n/a
* [ ] Did you run `yarn lint` in `/client`? n/a
* [ ] Did you run `yarn test` in `/client`? n/a
* [ ] Are your primary keys UUIDs on any new tables? n/a

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally
_(none)_
<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
All new AR models (with UUIDs) will need to inherit from this class instead of ApplicationRecord.  [just a reminder]

I'm happy to use a different name for the class.  This is just made sense to me.
