### PR TITLE
#179 RSpec.shared_examples for Rails model API actions

### DIFF
--- a/spec/requests/api/v1/businesses_spec.rb
+++ b/spec/requests/api/v1/businesses_spec.rb
@@ -12,22 +12,21 @@ RSpec.describe 'businesses API', type: :request do
     }
   end
 
-  it_behaves_like 'it lists all items for a user', 'business'
+  it_behaves_like 'it lists all items for a user', Business
 
-  it_behaves_like 'it creates an item', Business, 'business' do
+  it_behaves_like 'it creates an item', Business do
     let(:item_params) { business_params }
   end
 
-  it_behaves_like 'it retrieves an item with a slug, for a user', Business, 'business' do
+  it_behaves_like 'it retrieves an item with a slug, for a user', Business do
     let(:item_params) { business_params }
   end
 
-  it_behaves_like 'it updates an item with a slug', Business, 'business',
-                  'name', 'Hogwarts School', nil do
+  it_behaves_like 'it updates an item with a slug', Business, 'name', 'Hogwarts School', nil do
     let(:item_params) { business_params }
   end
 
-  it_behaves_like 'it deletes an item with a slug, for a user', Business, 'business' do
+  it_behaves_like 'it deletes an item with a slug, for a user', Business do
     let(:item_params) { business_params }
   end
 end

--- a/spec/requests/api/v1/businesses_spec.rb
+++ b/spec/requests/api/v1/businesses_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'businesses API', type: :request do
 
   it_behaves_like 'it lists all items for a user', 'business'
 
-  it_behaves_like 'it creates an item for a user', Business, 'business' do
+  it_behaves_like 'it creates an item', Business, 'business' do
     let(:item_params) { business_params }
   end
 
@@ -22,7 +22,7 @@ RSpec.describe 'businesses API', type: :request do
     let(:item_params) { business_params }
   end
 
-  it_behaves_like 'it updates an item with a slug, for a user', Business, 'business',
+  it_behaves_like 'it updates an item with a slug', Business, 'business',
                   'name', 'Hogwarts School', nil do
     let(:item_params) { business_params }
   end

--- a/spec/requests/api/v1/sites_spec.rb
+++ b/spec/requests/api/v1/sites_spec.rb
@@ -17,22 +17,21 @@ RSpec.describe 'sites API', type: :request do
     }
   end
 
-  it_behaves_like 'it lists all items for a user', 'site'
+  it_behaves_like 'it lists all items for a user', Site
 
-  it_behaves_like 'it creates an item', Site, 'site' do
+  it_behaves_like 'it creates an item', Site do
     let(:item_params) { site_params }
   end
 
-  it_behaves_like 'it retrieves an item with a slug, for a user', Site, 'site' do
+  it_behaves_like 'it retrieves an item with a slug, for a user', Site do
     let(:item_params) { site_params }
   end
 
-  it_behaves_like 'it updates an item with a slug', Site, 'site',
-                  'name', 'Hogwarts School', nil do
+  it_behaves_like 'it updates an item with a slug', Site, 'name', 'Hogwarts School', nil do
     let(:item_params) { site_params }
   end
 
-  it_behaves_like 'it deletes an item with a slug, for a user', Site, 'site' do
+  it_behaves_like 'it deletes an item with a slug, for a user', Site do
     let(:item_params) { site_params }
   end
 end

--- a/spec/requests/api/v1/sites_spec.rb
+++ b/spec/requests/api/v1/sites_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'sites API', type: :request do
 
   it_behaves_like 'it lists all items for a user', 'site'
 
-  it_behaves_like 'it creates an item for a user', Site, 'site' do
+  it_behaves_like 'it creates an item', Site, 'site' do
     let(:item_params) { site_params }
   end
 
@@ -27,7 +27,7 @@ RSpec.describe 'sites API', type: :request do
     let(:item_params) { site_params }
   end
 
-  it_behaves_like 'it updates an item with a slug, for a user', Site, 'site',
+  it_behaves_like 'it updates an item with a slug', Site, 'site',
                   'name', 'Hogwarts School', nil do
     let(:item_params) { site_params }
   end

--- a/spec/requests/api/v1/sites_spec.rb
+++ b/spec/requests/api/v1/sites_spec.rb
@@ -3,7 +3,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'sites API', type: :request do
-  let(:business_id) { create(:business).id }
+  let(:business_id) { create(:business, user: create(:confirmed_user)).id }
   let!(:site_params) do
     {
       "name": 'Evesburg Educational Center',
@@ -17,257 +17,22 @@ RSpec.describe 'sites API', type: :request do
     }
   end
 
-  path '/api/v1/sites' do
-    get 'lists all sites for a user' do
-      tags 'sites'
-      produces 'application/json'
-      parameter name: 'Accept', in: :header, type: :string, default: 'application/vnd.pieforproviders.v1+json'
-      # parameter name: 'Authorization', in: :header, type: :string, default: 'Bearer <token>'
-      # security [{ token: [] }]
+  it_behaves_like 'it lists all items for a user', 'site'
 
-      context 'on the right api version' do
-        include_context 'correct api version header'
-        context 'when authenticated' do
-          include_context 'authenticated user'
-          response '200', 'sites found' do
-            run_test! do
-              expect(response).to match_response_schema('sites')
-            end
-          end
-        end
-
-        context 'when not authenticated' do
-          response '401', 'not authorized' do
-            run_test!
-          end
-        end
-      end
-
-      context 'on the wrong api version' do
-        include_context 'incorrect api version header'
-        context 'when authenticated' do
-          include_context 'authenticated user'
-          response '500', 'internal server error' do
-            run_test!
-          end
-        end
-
-        context 'when not authenticated' do
-          response '500', 'internal server error' do
-            run_test!
-          end
-        end
-      end
-    end
-
-    post 'creates a site' do
-      tags 'sites'
-      consumes 'application/json', 'application/xml'
-      parameter name: 'Accept', in: :header, type: :string, default: 'application/vnd.pieforproviders.v1+json'
-      parameter name: :site, in: :body, schema: {
-        '$ref' => '#/definitions/createSite'
-      }
-
-      context 'on the right api version' do
-        include_context 'correct api version header'
-        context 'when authenticated' do
-          include_context 'authenticated user'
-          response '201', 'site created' do
-            let(:site) { { "site": site_params } }
-            run_test! do
-              expect(response).to match_response_schema('site')
-            end
-          end
-          response '422', 'invalid request' do
-            let(:site) { { "site": { "title": 'whatever' } } }
-            run_test!
-          end
-        end
-
-        context 'when not authenticated' do
-          response '401', 'not authorized' do
-            let(:site) { { "site": site_params } }
-            run_test!
-          end
-        end
-      end
-
-      context 'on the wrong api version' do
-        include_context 'incorrect api version header'
-        context 'when authenticated' do
-          include_context 'authenticated user'
-          response '500', 'internal server error' do
-            let(:site) { { "site": site_params } }
-            run_test!
-          end
-        end
-
-        context 'when not authenticated' do
-          response '500', 'internal server error' do
-            let(:site) { { "site": site_params } }
-            run_test!
-          end
-        end
-      end
-    end
+  it_behaves_like 'it creates an item for a user', Site, 'site' do
+    let(:item_params) { site_params }
   end
 
-  path '/api/v1/sites/{slug}' do
-    parameter name: :slug, in: :path, type: :string
-    let(:slug) { Site.create!(site_params).slug }
+  it_behaves_like 'it retrieves an item with a slug, for a user', Site, 'site' do
+    let(:item_params) { site_params }
+  end
 
-    get 'retrieves a site' do
-      tags 'sites'
-      produces 'application/json', 'application/xml'
-      parameter name: 'Accept', in: :header, type: :string, default: 'application/vnd.pieforproviders.v1+json'
-      # parameter name: 'Authorization', in: :header, type: :string, default: 'Bearer <token>'
-      # security [{ token: [] }]
+  it_behaves_like 'it updates an item with a slug, for a user', Site, 'site',
+                  'name', 'Hogwarts School', nil do
+    let(:item_params) { site_params }
+  end
 
-      context 'on the right api version' do
-        include_context 'correct api version header'
-        context 'when authenticated' do
-          include_context 'authenticated user'
-          response '200', 'site found' do
-            run_test! do
-              expect(response).to match_response_schema('site')
-            end
-          end
-
-          response '404', 'site not found' do
-            let(:slug) { 'invalid' }
-            run_test!
-          end
-        end
-
-        context 'when not authenticated' do
-          response '401', 'not authorized' do
-            run_test!
-          end
-        end
-      end
-
-      context 'on the wrong api version' do
-        include_context 'incorrect api version header'
-        context 'when authenticated' do
-          include_context 'authenticated user'
-          response '500', 'internal server error' do
-            run_test!
-          end
-        end
-
-        context 'when not authenticated' do
-          response '500', 'internal server error' do
-            run_test!
-          end
-        end
-      end
-    end
-
-    put 'updates a site' do
-      tags 'sites'
-      consumes 'application/json', 'application/xml'
-      produces 'application/json', 'application/xml'
-      parameter name: 'Accept', in: :header, type: :string, default: 'application/vnd.pieforproviders.v1+json'
-      # parameter name: 'Authorization', in: :header, type: :string, default: 'Bearer <token>'
-      parameter name: :site, in: :body, schema: {
-        '$ref' => '#/definitions/updateSite'
-      }
-      # security [{ token: [] }]
-
-      context 'on the right api version' do
-        include_context 'correct api version header'
-        context 'when authenticated' do
-          include_context 'authenticated user'
-          response '200', 'site updated' do
-            let(:site) { { "site": site_params.merge("name": 'Hogwarts School') } }
-            run_test! do
-              expect(response).to match_response_schema('site')
-              expect(response.parsed_body['name']).to eq('Hogwarts School')
-            end
-          end
-
-          response '422', 'site cannot be updated' do
-            let(:site) { { "site": { "name": nil } } }
-            run_test!
-          end
-
-          response '404', 'site not found' do
-            let(:slug) { 'invalid' }
-            let(:site) { { "site": site_params } }
-            run_test!
-          end
-        end
-
-        context 'when not authenticated' do
-          response '401', 'not authorized' do
-            let(:site) { { "site": site_params } }
-            run_test!
-          end
-        end
-      end
-
-      context 'on the wrong api version' do
-        include_context 'incorrect api version header'
-        context 'when authenticated' do
-          include_context 'authenticated user'
-          response '500', 'internal server error' do
-            let(:site) { { "site": site_params } }
-            run_test!
-          end
-        end
-
-        context 'when not authenticated' do
-          response '500', 'internal server error' do
-            let(:site) { { "site": site_params } }
-            run_test!
-          end
-        end
-      end
-    end
-
-    delete 'deletes a site' do
-      tags 'sites'
-      produces 'application/json', 'application/xml'
-      parameter name: 'Accept', in: :header, type: :string, default: 'application/vnd.pieforproviders.v1+json'
-      # parameter name: 'Authorization', in: :header, type: :string, default: 'Bearer <token>'
-      # security [{ token: [] }]
-
-      context 'on the right api version' do
-        include_context 'correct api version header'
-        context 'when authenticated' do
-          include_context 'authenticated user'
-          response '204', 'site deleted' do
-            run_test!
-          end
-
-          response '404', 'site not found' do
-            let(:slug) { 'invalid' }
-            run_test!
-          end
-        end
-
-        context 'when not authenticated' do
-          response '401', 'not authorized' do
-            run_test!
-          end
-        end
-      end
-
-      context 'on the wrong api version' do
-        include_context 'incorrect api version header'
-        context 'when authenticated' do
-          include_context 'authenticated user'
-          response '500', 'internal server error' do
-            run_test!
-          end
-        end
-
-        context 'when not authenticated' do
-          response '500', 'internal server error' do
-            run_test!
-          end
-        end
-      end
-    end
+  it_behaves_like 'it deletes an item with a slug, for a user', Site, 'site' do
+    let(:item_params) { site_params }
   end
 end

--- a/spec/support/shared_examples_api_request.rb
+++ b/spec/support/shared_examples_api_request.rb
@@ -13,7 +13,7 @@ VALID_API_PATH = '/api/v1'
 # Ex: Assume you are testing the API calls for creating a Payment. The
 #     item_params are the parameters needed to create a Payment.
 #
-#      it_behaves_like 'it creates an item for a user', Payment, 'payment' do
+#      it_behaves_like 'it creates an item', Payment, 'payment' do
 #        let(:item_params) {
 #          {
 #            "agency_id": agency_id,
@@ -200,7 +200,7 @@ end
 #      and as part of the schema name in the schema definitions.
 #      It is pluralized and used for the path and the tags.
 #
-RSpec.shared_examples 'it creates an item for a user' do |item_class, item_name|
+RSpec.shared_examples 'it creates an item' do |item_class, item_name|
   item_plural = item_name.pluralize
   item_name_symbol = item_name.to_sym
 
@@ -253,7 +253,7 @@ end
 #    update_valid_value [String | Number | nil] - valid value for the updated value for the attribute
 #    update_invalid_value  [String | Number | nil] - invalid value for the attribute so that the server returns a 422 (cannot be updated) error
 #
-RSpec.shared_examples 'it updates an item with a slug, for a user' do |item_class, item_name, update_attribute, update_valid_value, update_invalid_value|
+RSpec.shared_examples 'it updates an item with a slug' do |item_class, item_name, update_attribute, update_valid_value, update_invalid_value|
   item_plural = item_name.pluralize
   item_name_symbol = item_name.to_sym
 

--- a/spec/support/shared_examples_api_request.rb
+++ b/spec/support/shared_examples_api_request.rb
@@ -112,11 +112,16 @@ end
 
 # ------------------------------------------------------------------------------
 
+def name_from_class(item_class)
+  item_class.name.downcase
+end
+
 #  This is the parameter passed to this example:
 #    item_name [String] - the name of the item (singular).
 #      It is pluralized and used for the path, the tags, and the expected schema.
 #
-RSpec.shared_examples 'it lists all items for a user' do |item_name|
+RSpec.shared_examples 'it lists all items for a user' do |item_class|
+  item_name = name_from_class(item_class)
   item_plural = item_name.pluralize
 
   path "#{VALID_API_PATH}/#{item_plural}" do
@@ -154,7 +159,8 @@ end
 #      with the item_params, and to get the slug for the created item.
 #    item_name [String] - the name of the item (singular). It will be pluralized to get a list of the items
 #      It is pluralized and used for the path and the tags.
-RSpec.shared_examples 'it retrieves an item with a slug, for a user' do |item_class, item_name|
+RSpec.shared_examples 'it retrieves an item with a slug, for a user' do |item_class|
+  item_name = name_from_class(item_class)
   item_plural = item_name.pluralize
 
   path "#{VALID_API_PATH}/#{item_plural}/{slug}" do
@@ -200,7 +206,8 @@ end
 #      and as part of the schema name in the schema definitions.
 #      It is pluralized and used for the path and the tags.
 #
-RSpec.shared_examples 'it creates an item' do |item_class, item_name|
+RSpec.shared_examples 'it creates an item' do |item_class|
+  item_name = name_from_class(item_class)
   item_plural = item_name.pluralize
   item_name_symbol = item_name.to_sym
 
@@ -253,7 +260,8 @@ end
 #    update_valid_value [String | Number | nil] - valid value for the updated value for the attribute
 #    update_invalid_value  [String | Number | nil] - invalid value for the attribute so that the server returns a 422 (cannot be updated) error
 #
-RSpec.shared_examples 'it updates an item with a slug' do |item_class, item_name, update_attribute, update_valid_value, update_invalid_value|
+RSpec.shared_examples 'it updates an item with a slug' do |item_class, update_attribute, update_valid_value, update_invalid_value|
+  item_name = name_from_class(item_class)
   item_plural = item_name.pluralize
   item_name_symbol = item_name.to_sym
 
@@ -309,7 +317,8 @@ end
 #      with the item_params, and to get the slug for the created item.
 #    item_name [String] - the name of the item (singular). It will be pluralized to get a list of the items
 #      It is pluralized and used for the path and the tags.
-RSpec.shared_examples 'it deletes an item with a slug, for a user' do |item_class, item_name|
+RSpec.shared_examples 'it deletes an item with a slug, for a user' do |item_class|
+  item_name = name_from_class(item_class)
   item_plural = item_name.pluralize
 
   path "#{VALID_API_PATH}/#{item_plural}/{slug}" do

--- a/spec/support/shared_examples_api_request.rb
+++ b/spec/support/shared_examples_api_request.rb
@@ -1,0 +1,343 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+VALID_API_PATH = '/api/v1'
+
+# These are shared examples for typical API calls for a Rails model.
+#
+# Some examples expect _item_params_ to be defined (e.g. with a let(:item_params) block)
+# to be used as parameters that are sent to the server.
+# The examples that expect item_params to be defined end with '... with parameters'.
+#
+# Ex: Assume you are testing the API calls for creating a Payment. The
+#     item_params are the parameters needed to create a Payment.
+#
+#      it_behaves_like 'it creates an item for a user', Payment, 'payment' do
+#        let(:item_params) {
+#          {
+#            "agency_id": agency_id,
+#            "amount_cents": '123400',
+#            "care_finished_on": '2020-06-01',
+#            "care_started_on": '2020-01-01',
+#            "discrepancy_cents": '7890',
+#            "paid_on": '2020-07-07',
+#            "site_id": site_id
+#          }
+#        }
+#      end
+#
+#     You should define 'agency_id' and 'site_id' and any other values/variables
+#     as needed.
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# Examples that test for common error conditions:
+
+# This example expects the following to be defined with a let(:) block:
+#  item_params - parameters to be passed to the server
+RSpec.shared_examples 'server error responses for wrong api version with parameters' do |item_name|
+  context 'on the wrong api version' do
+    include_context 'incorrect api version header'
+    context 'when authenticated' do
+      include_context 'authenticated user'
+      response '500', 'internal server error' do
+        let(item_name.to_sym) { { item_name => item_params } }
+        run_test!
+      end
+    end
+
+    context 'when not authenticated' do
+      response '500', 'internal server error' do
+        let(item_name.to_sym) { { item_name => item_params } }
+        run_test!
+      end
+    end
+  end
+end
+
+RSpec.shared_examples 'server error responses for wrong api version' do
+  context 'on the wrong api version' do
+    include_context 'incorrect api version header'
+    context 'when authenticated' do
+      include_context 'authenticated user'
+      response '500', 'internal server error' do
+        run_test!
+      end
+    end
+
+    context 'when not authenticated' do
+      response '500', 'internal server error' do
+        run_test!
+      end
+    end
+  end
+end
+
+# This example expects the following to be defined with a let(:) block:
+#  item_params - parameters to be passed to the server
+RSpec.shared_examples '401 error if not authenticated with parameters' do |item_name|
+  context 'when not authenticated' do
+    response '401', 'not authorized' do
+      let(item_name.to_sym) { { item_name => item_params } }
+      run_test!
+    end
+  end
+end
+
+RSpec.shared_examples '401 error if not authenticated' do
+  context 'when not authenticated' do
+    response '401', 'not authorized' do
+      run_test!
+    end
+  end
+end
+
+# This example expects the following to be defined with a let(:) block:
+#  item_params - parameters to be passed to the server
+RSpec.shared_examples '404 not found with parameters' do |item_name|
+  response '404', "#{item_name} not found" do
+    let(:slug) { 'invalid' }
+    let(item_name.to_sym) { { item_name => item_params } }
+    run_test!
+  end
+end
+
+RSpec.shared_examples '404 not found' do |item_name|
+  response '404', "#{item_name} not found" do
+    let(:slug) { 'invalid' }
+    run_test!
+  end
+end
+
+# ------------------------------------------------------------------------------
+
+#  This is the parameter passed to this example:
+#    item_name [String] - the name of the item (singular).
+#      It is pluralized and used for the path, the tags, and the expected schema.
+#
+RSpec.shared_examples 'it lists all items for a user' do |item_name|
+  item_plural = item_name.pluralize
+
+  path "#{VALID_API_PATH}/#{item_plural}" do
+    get "lists all #{item_plural} for a user" do
+      tags item_plural
+      produces 'application/json'
+      parameter name: 'Accept', in: :header, type: :string, default: 'application/vnd.pieforproviders.v1+json'
+      # parameter name: 'Authorization', in: :header, type: :string, default: 'Bearer <token>'
+      # security [{ token: [] }]
+
+      context 'on the right api version' do
+        include_context 'correct api version header'
+        context 'when authenticated' do
+          include_context 'authenticated user'
+          response '200', "#{item_plural} found" do
+            run_test! do
+              expect(response).to match_response_schema(item_plural)
+            end
+          end
+        end
+
+        it_behaves_like '401 error if not authenticated'
+      end
+
+      it_behaves_like 'server error responses for wrong api version'
+    end
+  end
+end
+
+# This example expects the following to be defined with a let(:) block:
+#  item_params - parameters to be passed to the server
+#
+#  These are the parameters passed to this example:
+#    item_class [Class] - the class for the item; is used to create a new item
+#      with the item_params, and to get the slug for the created item.
+#    item_name [String] - the name of the item (singular). It will be pluralized to get a list of the items
+#      It is pluralized and used for the path and the tags.
+RSpec.shared_examples 'it retrieves an item with a slug, for a user' do |item_class, item_name|
+  item_plural = item_name.pluralize
+
+  path "#{VALID_API_PATH}/#{item_plural}/{slug}" do
+    parameter name: :slug, in: :path, type: :string
+    let(:slug) { (item_class.send :create!, item_params).slug }
+
+    get "retrieves a #{item_name}" do
+      tags item_plural
+      produces 'application/json', 'application/xml'
+      parameter name: 'Accept', in: :header, type: :string, default: 'application/vnd.pieforproviders.v1+json'
+      # parameter name: 'Authorization', in: :header, type: :string, default: 'Bearer <token>'
+      # security [{ token: [] }]
+
+      context 'on the right api version' do
+        include_context 'correct api version header'
+        context 'when authenticated' do
+          include_context 'authenticated user'
+          response '200', "#{item_name} found" do
+            run_test! do
+              expect(response).to match_response_schema(item_name)
+            end
+          end
+
+          it_behaves_like '404 not found with parameters', item_name
+        end
+
+        it_behaves_like '401 error if not authenticated with parameters', item_name
+      end
+
+      it_behaves_like 'server error responses for wrong api version with parameters', item_name
+    end
+  end
+end
+
+# This example expects the following to be defined with a let(:) block:
+#  item_params - parameters to be passed to the server
+#
+#  These are the parameters passed to this example:
+#    item_class [Class] - the class for the item; is used to create a new item
+#      with the item_params, and to get the slug for the created item.
+#    item_name [String] - the name of the item (singular).
+#      It is used as a key in the parameters sent to the server
+#      and as part of the schema name in the schema definitions.
+#      It is pluralized and used for the path and the tags.
+#
+RSpec.shared_examples 'it creates an item for a user' do |item_class, item_name|
+  item_plural = item_name.pluralize
+  item_name_symbol = item_name.to_sym
+
+  path "#{VALID_API_PATH}/#{item_plural}" do
+    post "creates a #{item_name}" do
+      tags item_plural
+      consumes 'application/json', 'application/xml'
+      parameter name: 'Accept', in: :header, type: :string, default: 'application/vnd.pieforproviders.v1+json'
+      parameter name: item_name_symbol, in: :body, schema: {
+        '$ref' => "#/definitions/create#{item_class}"
+      }
+
+      context 'on the right api version' do
+        include_context 'correct api version header'
+        context 'when authenticated' do
+          include_context 'authenticated user'
+
+          response '201', "#{item_name} created" do
+            let(item_name_symbol) { { item_name => item_params } }
+            run_test! do
+              expect(response).to match_response_schema(item_name)
+            end
+          end
+
+          response '422', 'invalid request' do
+            let(item_name_symbol) { { item_name => { 'blorf': 'whatever' } } }
+            run_test!
+          end
+        end
+
+        it_behaves_like '401 error if not authenticated with parameters', item_name
+      end
+
+      it_behaves_like 'server error responses for wrong api version with parameters', item_name
+    end
+  end
+end
+
+# This example expects the following to be defined with a let(:) block:
+#  item_params - parameters to be passed to the server
+#
+#  These are the parameters passed to this example:
+#    item_class [Class] - the class for the item; is used to create a new item
+#      with the item_params, and to get the slug for the created item.
+#    item_name [String] - the name of the item (singular).
+#      It is used as a key in the parameters sent to the server
+#      and as part of the schema name in the schema definitions.
+#      It is pluralized and used for the path and the tags.
+#    update_attribute [String] - attribute name to be updated
+#    update_valid_value [String | Number | nil] - valid value for the updated value for the attribute
+#    update_invalid_value  [String | Number | nil] - invalid value for the attribute so that the server returns a 422 (cannot be updated) error
+#
+RSpec.shared_examples 'it updates an item with a slug, for a user' do |item_class, item_name, update_attribute, update_valid_value, update_invalid_value|
+  item_plural = item_name.pluralize
+  item_name_symbol = item_name.to_sym
+
+  path "#{VALID_API_PATH}/#{item_plural}/{slug}" do
+    parameter name: :slug, in: :path, type: :string
+    let(:slug) { (item_class.send :create!, item_params).slug }
+
+    put "updates a #{item_name}" do
+      tags item_plural
+      consumes 'application/json', 'application/xml'
+      produces 'application/json', 'application/xml'
+      parameter name: 'Accept', in: :header, type: :string, default: 'application/vnd.pieforproviders.v1+json'
+      # parameter name: 'Authorization', in: :header, type: :string, default: 'Bearer <token>'
+
+      parameter name: item_name_symbol, in: :body, schema: {
+        '$ref' => "#/definitions/update#{item_class}"
+      }
+      # security [{ token: [] }]
+
+      context 'on the right api version' do
+        include_context 'correct api version header'
+        context 'when authenticated' do
+          include_context 'authenticated user'
+          response '200', "#{item_name} updated" do
+            let(item_name_symbol) { { item_name => item_params.merge(update_attribute => update_valid_value) } }
+            run_test! do
+              expect(response).to match_response_schema(item_name)
+              expect(response.parsed_body[update_attribute]).to eq(update_valid_value)
+            end
+          end
+
+          response '422', "#{item_name} cannot be updated" do
+            let(item_name_symbol) { { item_name => { update_attribute => update_invalid_value } } }
+            run_test!
+          end
+
+          it_behaves_like '404 not found with parameters', item_name
+        end
+
+        it_behaves_like '401 error if not authenticated with parameters', item_name
+      end
+
+      it_behaves_like 'server error responses for wrong api version with parameters', item_name
+    end
+  end
+end
+
+# This example expects the following to be defined with a let(:) block:
+#  item_params - parameters to be passed to the server
+#
+#  These are the parameters passed to this example:
+#    item_class [Class] - the class for the item; is used to create a new item
+#      with the item_params, and to get the slug for the created item.
+#    item_name [String] - the name of the item (singular). It will be pluralized to get a list of the items
+#      It is pluralized and used for the path and the tags.
+RSpec.shared_examples 'it deletes an item with a slug, for a user' do |item_class, item_name|
+  item_plural = item_name.pluralize
+
+  path "#{VALID_API_PATH}/#{item_plural}/{slug}" do
+    parameter name: :slug, in: :path, type: :string
+    let(:slug) { (item_class.send :create!, item_params).slug }
+
+    delete "deletes a #{item_name}" do
+      tags item_plural
+      produces 'application/json', 'application/xml'
+      parameter name: 'Accept', in: :header, type: :string, default: 'application/vnd.pieforproviders.v1+json'
+      # parameter name: 'Authorization', in: :header, type: :string, default: 'Bearer <token>'
+      # security [{ token: [] }]
+
+      context 'on the right api version' do
+        include_context 'correct api version header'
+        context 'when authenticated' do
+          include_context 'authenticated user'
+          response '204', "#{item_name} deleted" do
+            run_test!
+          end
+
+          it_behaves_like '404 not found', item_name
+        end
+
+        it_behaves_like '401 error if not authenticated'
+      end
+
+      it_behaves_like 'server error responses for wrong api version'
+    end
+  end
+end


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->
#179 DRY API Specs  Use RSpec.shared_examples for the common API requests for Rails models.  Pass parameters to the shared_examples as needed to specify names, classes, data to be updated, etc.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write tests?
* [x] Did you run `rails rswag` from the root?
* [x] Did you run `rubocop` from the root?
* [ ] Did you run `yarn lint` in `/client`?
* [ ] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->

The shared examples show how much duplication there is in the specs.  Just the names of the classes (and the data to change with the `update` action) vary.  I am passing in the lower case 'item name,' but we could do away with that, since it's based on the class name.

This PR is here so it can be discussed/reviewed. 
There are likely things that can be further refactored/cleaned up/improved; I wanted to get this pushed so we can at least think about it and discuss.

I'm not happy with the names of the shared examples, but those can be changed later.

