### PR TITLE
Fix "Rendered more hooks than during the previous render" error

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -34,13 +34,13 @@ const App = () => {
             <Route path="/signup">
               <AuthLayout
                 backgroundImageClass="auth-image"
-                rightColumnContent={Signup}
+                contentComponent={Signup}
               />
             </Route>
             <Route path="/login">
               <AuthLayout
                 backgroundImageClass="auth-image"
-                rightColumnContent={Login}
+                contentComponent={Login}
               />
             </Route>
             <AuthorizedRoute exact path="/getting-started">
@@ -55,7 +55,7 @@ const App = () => {
             <Route path="/confirmation">
               <AuthLayout
                 backgroundImageClass="auth-image"
-                rightColumnContent={Confirmation}
+                contentComponent={Confirmation}
               />
             </Route>
             <Route exact path="/">

--- a/client/src/_shared/AuthLayout.js
+++ b/client/src/_shared/AuthLayout.js
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types'
 import piefulltanlogo from '_assets/piefulltanlogo.svg'
 import '_assets/styles/layouts.css'
 
-export function AuthLayout({ backgroundImageClass, rightColumnContent }) {
+export function AuthLayout({
+  backgroundImageClass,
+  contentComponent: ContentComponent
+}) {
   return (
     <div className="grid grid-cols-1 medium:grid-cols-8 large:grid-cols-2 h-screen">
       <div
@@ -19,7 +22,7 @@ export function AuthLayout({ backgroundImageClass, rightColumnContent }) {
               src={piefulltanlogo}
               className="w-24 medium:w-48 mt-0 mb-8 medium:mb-16 large:mb-12 mx-auto"
             />
-            {rightColumnContent()}
+            <ContentComponent />
           </div>
         </div>
       </div>
@@ -29,5 +32,5 @@ export function AuthLayout({ backgroundImageClass, rightColumnContent }) {
 
 AuthLayout.propTypes = {
   backgroundImageClass: PropTypes.string,
-  rightColumnContent: PropTypes.func
+  contentComponent: PropTypes.func
 }


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->
Fixes https://github.com/pieforproviders/pieforproviders/issues/156

When you go to http://localhost:3000, the `AuthLayout` component renders the `Login` component by calling the function (i.e. `rightColumnContent()`) and a few hooks from the `Login` component are rendered. If you click on the **SIGN UP** link, the `Signup` function is called and it uses more hooks than the `Login` component. This is the reason for the `Rendered more hooks than during the previous render` error.

When you go to http://localhost:3000/signup, the hooks from the `Signup` component will be rendered the first time. If you click on the **LOG IN** link, there'll be fewer hooks rendered and you'll run into the `Rendered fewer hooks than expected. This may be caused by an accidental early return statement` error.

The PR attempts to fix the issue by rendering the component with the `React.createElement` call (i.e. `<ContentComponent />`) — the `AuthLayout` component no longer has to worry about the order of the hooks in the different render. It is delegated to the individual components (`Login` and `Signup`).

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `rails rswag` from the root?
* [ ] Did you run `rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
1. Run `foreman start` from the root
2. Click on the **SIGN UP** link from the login page
3. Click on the **LOG IN** link from the signup page. They should both render without any errors.
