### PR TITLE
Display an error message if the email address is already taken

### DIFF
--- a/client/src/Signup/Signup.js
+++ b/client/src/Signup/Signup.js
@@ -30,6 +30,7 @@ export function Signup() {
   })
   const [multiBusiness, setMultiBusiness] = useState(null)
   const { makeRequest } = useApiResponse()
+  const [errors, setErrors] = useState(null)
   let history = useHistory()
 
   const onFinish = async () => {
@@ -42,9 +43,9 @@ export function Signup() {
     if (response.status === 201) {
       history.push('/confirmation')
     } else {
+      const { errors } = await response.json()
+      setErrors(errors[0].detail)
       // TODO: Sentry
-      // TODO: Display error to user
-      console.log('error creating')
     }
   }
 
@@ -292,6 +293,9 @@ export function Signup() {
               message: 'Email address is required'
             }
           ]}
+          hasFeedback={!!errors?.email}
+          validateStatus={errors?.email && 'error'}
+          help={errors?.email && `Email ${errors.email.join(', ')}`}
         >
           <Input
             placeholder="amanda@gmail.com"


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

When a user tries to sign up with an existing email address, an _Email has already been taken_ error message is displayed. Previously, the request failed silently and no feedback was given.

**Screenshot**

<img width="590" alt="image" src="https://user-images.githubusercontent.com/7039523/90084411-e3242700-dcda-11ea-8323-7c06df70db06.png">

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `rails rswag` from the root?
* [ ] Did you run `rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

1. Try to sign up with an existing email address (test@test.com)
2. The _Email has already been taken_ error message should be displayed
