### PR TITLE
Redirect the user to the dashboard if logged in

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,6 +16,7 @@ import NotFound from './NotFound'
 import ErrorBoundary from './ErrorBoundary'
 import CSVImport from './CSVImport'
 import { AuthLayout } from '_shared'
+import { isUserLoggedIn } from '_utils'
 
 const App = () => {
   useEffect(() => {
@@ -59,7 +60,7 @@ const App = () => {
               />
             </Route>
             <Route exact path="/">
-              <Redirect to={'/login'} />
+              <Redirect to={isUserLoggedIn ? '/dashboard' : '/login'} />
             </Route>
             <Route component={NotFound} />
           </Switch>

--- a/client/src/_utils/index.js
+++ b/client/src/_utils/index.js
@@ -1,0 +1,1 @@
+export const isUserLoggedIn = () => !!localStorage.getItem('pie-token')


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->
After logging in, if the user tries to go `/`, they are redirected to `/login` even when they are already logged in. This PR fixes it by redirecting the user to the dashboard instead.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `rails rswag` from the root?
* [ ] Did you run `rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧳 Steps to test
1. Get the app up and running and log in
2. Go to `/`. You should be redirected to `/dashboard`

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->

The `isUserLoggedIn` function just checks for the presence of `pie-token` from the local storage as done [here](https://github.com/pieforproviders/pieforproviders/blob/develop/client/src/_utils/_routes/AuthorizedRoute.js#L14). I am not sure if this is fine to ensure a user is logged in though. 
