### PR TITLE
Fix /login route rendering JSON

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
+is_html_request = ->(request) { !request.xhr? && request.format.html? }
+
 Rails.application.routes.draw do
+  # This is required because the `devise_for` call generates a `GET /login`
+  # route which we don't want to expose.
+  get '/login', to: 'static#fallback_index_html', constraints: is_html_request
+
   devise_for :users,
              path: '',
              path_names: {
@@ -24,9 +30,7 @@ Rails.application.routes.draw do
     end
   end
 
-  get '*path', to: 'static#fallback_index_html', constraints: lambda { |request|
-    !request.xhr? && request.format.html?
-  }
+  get '*path', to: 'static#fallback_index_html', constraints: is_html_request
 end
 
 # rubocop:disable Layout/LineLength


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->
#200 

When someone goes to `/login`, the `login` route set from the devise gem gets matched as it's defined at the top. The `devise_for` does support a [`skip`](https://github.com/heartcombo/devise/blob/9aa17eec07719a97385dd40fa05c4029983a1cd5/lib/devise/rails/routes.rb#L151) option but it skips all the routes from a controller. We only want to skip `GET /login`. This PR adds a `GET /login` route and maps it to `static#fallback_index_html` to let the React frontend take over. If there's a simple solution, do let me know!

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `rails rswag` from the root?
* [x] Did you run `rubocop` from the root?
* [ ] Did you run `yarn lint` in `/client`?
* [ ] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

Go to `http://localhost:3001/login`. You should find the frontend serving the login page.

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
