### PR TITLE
Display user's email address on the confirmation page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,7 +11,6 @@ import Dashboard from './Dashboard'
 import GettingStarted from './GettingStarted'
 import Login from './Login'
 import Signup from './Signup'
-import Confirmation from './Signup/Confirmation'
 import NotFound from './NotFound'
 import ErrorBoundary from './ErrorBoundary'
 import CasesImport from './CasesImport'
@@ -53,12 +52,6 @@ const App = () => {
             <AuthorizedRoute exact path="/cases/import">
               <CasesImport />
             </AuthorizedRoute>
-            <Route path="/confirmation">
-              <AuthLayout
-                backgroundImageClass="auth-image"
-                contentComponent={Confirmation}
-              />
-            </Route>
             <Route exact path="/">
               <Redirect to={isUserLoggedIn ? '/dashboard' : '/login'} />
             </Route>

--- a/client/src/Signup/Confirmation.js
+++ b/client/src/Signup/Confirmation.js
@@ -5,13 +5,11 @@ import LabelImportantIcon from '@material-ui/icons/LabelImportant'
 
 const { Title, Text, Link } = Typography
 
-// TODO: placeholder for actual user's email that signed up
-const userEmail = 'chelsea@pieforproviders.com'
-const pieEmail = 'noreply@pieforproviders.com'
+const pieEmail = 'tech@pieforproviders.com'
 
 function ListItem({ children }) {
   return (
-    <div className="flex align-center justify-left mb-1">
+    <div className="flex items-center justify-left mb-1">
       <LabelImportantIcon
         className="mr-1"
         style={{ color: '#000', width: '16px' }}
@@ -21,7 +19,11 @@ function ListItem({ children }) {
   )
 }
 
-const Confirmation = () => {
+ListItem.propTypes = {
+  children: PropTypes.element.isRequired
+}
+
+const Confirmation = ({ userEmail }) => {
   return (
     <>
       <Title className="text-center">Thanks for signing up!</Title>
@@ -55,8 +57,8 @@ const Confirmation = () => {
   )
 }
 
-ListItem.propTypes = {
-  children: PropTypes.element.isRequired
+Confirmation.propTypes = {
+  userEmail: PropTypes.string.isRequired
 }
 
 export default Confirmation

--- a/client/src/Signup/Signup.js
+++ b/client/src/Signup/Signup.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import ReactGA from 'react-ga'
-import { Link, useHistory } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { Form, Input, Button, Select, Radio, Checkbox } from 'antd'
 import MaskedInput from 'antd-mask-input'
 import { useTranslation } from 'react-i18next'
@@ -9,6 +9,7 @@ import '_assets/styles/form-overrides.css'
 import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked'
 import CheckCircleIcon from '@material-ui/icons/CheckCircle'
 import i18n from 'i18n'
+import Confirmation from './Confirmation'
 
 const { Option } = Select
 
@@ -31,9 +32,9 @@ export function Signup() {
     serviceAgreementAccepted: false
   })
   const [multiBusiness, setMultiBusiness] = useState(null)
-  const { makeRequest } = useApiResponse()
+  const [success, setSuccess] = useState(false)
   const [errors, setErrors] = useState(null)
-  let history = useHistory()
+  const { makeRequest } = useApiResponse()
   const { t } = useTranslation()
 
   const onFinish = async () => {
@@ -44,7 +45,7 @@ export function Signup() {
       data: { user: user }
     })
     if (response.status === 201) {
-      history.push('/confirmation')
+      setSuccess(true)
     } else {
       const { errors } = await response.json()
       setErrors(errors[0].detail)
@@ -79,6 +80,10 @@ export function Signup() {
         </a>
       </>
     )
+  }
+
+  if (success) {
+    return <Confirmation userEmail={user.email} />
   }
 
   return (

--- a/client/src/Signup/__tests__/Confirmation.test.js
+++ b/client/src/Signup/__tests__/Confirmation.test.js
@@ -7,7 +7,7 @@ describe('<Confirmation />', () => {
   it('renders the signup confirmation page', () => {
     const { container } = render(
       <MemoryRouter initialEntries={['/']} initialIndex={0}>
-        <Confirmation />
+        <Confirmation userEmail="hey@hey.com" />
       </MemoryRouter>
     )
     expect(container).toHaveTextContent('Thanks for signing up')


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->
#194

- Displays the user's email on the confirmation view
- Replaces noreply@pieforproviders.com with tech@pieforproviders.com
- Fixes the list items alignment by replacing the `align-center` class with `items-center`

## Screenshot

<img width="1662" alt="image" src="https://user-images.githubusercontent.com/7039523/90945680-f70f0d80-e3eb-11ea-9a87-9538f563e0db.png">

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `rails rswag` from the root?
* [ ] Did you run `rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

1. Sign up for an account
2. You should find the email address you used to create the account in the first list item on the confirmation view. And the contact email should be tech@pieforproviders.com


## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
