### PR TITLE
Set up letter opener for email deliveries in dev environment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,17 +3,14 @@ DEVISE_JWT_SECRET_KEY= # generate by running `rails secret`
 PORT=3000 # local dev port
 
 # optional
-SENTRY_DSN= # staging and later envs
 TESTUSER_EMAIL=your@email.com (optional, default is test@test.com)
 TESTUSER_PASSWORD=yourpassword (optional, default is testpass1234!)
 PGUSER=yourlocalpostgresuser (optional, in case your local postgres installation needs this set)
 PGPASSWORD=yourlocalpostgrespassword (optional, in case your local postgres installation needs this set)
+MAIL_URL= # localhost:3000 (or other mail provider url)
 
-# devise mailer: required
-PERFORM_DELIVERIES=false # if you want to test sending actual emails: true
-
-# devise mailer: optional, only if you want to test sending actual emails
+# only for staging and production environments
+SENTRY_DSN= # staging and later envs
 SENDMAIL_USERNAME= # gmail address (or other mail provider address)
 SENDMAIL_PASSWORD= # gmail app password (or other mail provider password)
 MAIL_HOST= # gmail.com (or other mail provider host)
-MAIL_URL= # localhost:3000 (or other mail provider url)

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,7 @@ Metrics/BlockLength:
     - lib/tasks/**
     - config/initializers/**
     - config/environments/**
+    - config/routes.rb
 
 # screens are bigger now and long lines are more acceptable
 Layout/LineLength:

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ end
 group :development do
   gem 'annotate'
   gem 'guard-rspec', require: false
+  gem 'letter_opener_web', '~> 1.4'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'pgreset'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,14 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jwt (2.2.1)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
+    letter_opener_web (1.4.0)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -317,6 +325,7 @@ DEPENDENCIES
   faker
   guard-rspec
   json-schema
+  letter_opener_web (~> 1.4)
   listen (>= 3.0.5, < 3.2)
   money-rails
   pg (>= 0.18, < 2.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,21 +36,12 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # for testing devise mailers
-  config.action_mailer.perform_deliveries = ENV.fetch('PERFORM_DELIVERIES', 'false') == 'true'
+  config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { host: ENV.fetch('MAIL_URL', '') }
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.default_options = {
     from: ENV.fetch('SENDMAIL_USERNAME', '')
-  }
-  config.action_mailer.smtp_settings = {
-    user_name: ENV.fetch('SENDMAIL_USERNAME', ''),
-    password: ENV.fetch('SENDMAIL_PASSWORD', ''),
-    domain: ENV.fetch('MAIL_HOST', ''),
-    address: 'smtp.gmail.com',
-    port: '587',
-    authentication: :plain,
-    enable_starttls_auto: true
   }
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.action_controller.asset_host = 'http://assets.example.com'
 
   # default deliveries to true on production environments
-  config.action_mailer.perform_deliveries = ENV.fetch('PERFORM_DELIVERIES', 'true') == 'true'
+  config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { host: ENV.fetch('MAIL_URL', '') }
   config.action_mailer.default_options = {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
              }
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+
   scope module: :api, defaults: { format: :json }, path: 'api' do
     scope module: :v1, constraints: ApiConstraint.new(version: 1, default: true), path: 'v1' do
       resources :users, param: :slug


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->
- Sets up [letter_opener_web](https://github.com/fgrehm/letter_opener_web) to view emails in the browser in the development environment. This means less configuration which is a win.
- Removes `PERFORM_DELIVERIES` environment variable as we're always going to perform email deliveries in development and production environments

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `rails rswag` from the root?
* [x] Did you run `rubocop` from the root?
* [ ] Did you run `yarn lint` in `/client`?
* [ ] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
1. Sign up for an account
2. You should find the confirmation email show up in the the browser.

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
