### PR TITLE
Display phone number validation errors in the Sigup form

### DIFF
--- a/client/src/Signup/Signup.js
+++ b/client/src/Signup/Signup.js
@@ -201,7 +201,6 @@ export function Signup() {
                   pattern: /^\d{3}-\d{3}-\d{4}$/,
                   message: t('phoneNumberInvalid')
                 }
-                // TODO: these rules aren't working
               ]}
               hasFeedback={!!errors?.phone_number}
               validateStatus={errors?.phone_number && 'error'}


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

https://github.com/pieforproviders/pieforproviders/issues/206

If the phone number is already used, displays an error on the phone number input.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `rails rswag` from the root?
* [ ] Did you run `rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

1. Go to `/signup`
1. Fill out the details and use a phone number that's already used by another user
1. Click the **SIGN UP** button

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
