### PR TITLE
DRY json spec schemas and swagger_helper

### DIFF
--- a/spec/requests/api/v1/payments_spec.rb
+++ b/spec/requests/api/v1/payments_spec.rb
@@ -3,7 +3,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'payments API', type: :request do
-  # Use confirmed_user so that no confirimation email is sent
+  # Use confirmed_user so that no confirmation email is sent
   let(:confirmed_user) { create(:confirmed_user) }
   let(:user_id) { confirmed_user.id }
   let(:agency_id) { create(:agency).id }

--- a/spec/requests/api/v1/sites_spec.rb
+++ b/spec/requests/api/v1/sites_spec.rb
@@ -3,7 +3,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'sites API', type: :request do
-  # Use confirmed_user so that no confirimation email is sent
+  # Use confirmed_user so that no confirmation email is sent
   let(:business_id) { create(:business, user: create(:confirmed_user)).id }
   let!(:site_params) do
     {

--- a/spec/support/api/schemas/agencies.json
+++ b/spec/support/api/schemas/agencies.json
@@ -1,23 +1,5 @@
 {
   "type": "array",
   "required": ["agencies"],
-  "items": {
-    "type": "object",
-    "required": [
-      "active",
-      "created_at",
-      "id",
-      "name",
-      "state",
-      "updated_at"
-    ],
-    "properties": {
-      "active": { "type": "boolean" },
-      "created_at": { "type": "string" , "format": "date-time" },
-      "id": { "type": "string" },
-      "name": { "type": "string" },
-      "state": { "type": "string" },
-      "updated_at": { "type": "string" , "format": "date-time" }
-    }
-  }
+  "items": {"$ref":"agency.json"}
 }

--- a/spec/support/api/schemas/agency.json
+++ b/spec/support/api/schemas/agency.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "required": [
+    "active",
     "created_at",
     "id",
     "name",

--- a/spec/support/api/schemas/businesses.json
+++ b/spec/support/api/schemas/businesses.json
@@ -1,27 +1,5 @@
 {
   "type": "array",
   "required": ["businesses"],
-  "items": {
-    "type": "object",
-    "required": [
-      "active",
-      "category",
-      "created_at",
-      "id",
-      "name",
-      "slug",
-      "updated_at",
-      "user_id"
-    ],
-    "properties": {
-      "active": { "type": "boolean" },
-      "category": { "type": "string" },
-      "created_at": { "type": "string" , "format": "date-time" },
-      "id": { "type": "string" },
-      "name": { "type": "string" },
-      "slug": { "type": "string" },
-      "updated_at": { "type": "string" , "format": "date-time" },
-      "user_id": { "type": "string", "format": "uuid" }
-    }
-  }
+  "items": {"$ref":"business.json"}
 }

--- a/spec/support/api/schemas/children.json
+++ b/spec/support/api/schemas/children.json
@@ -1,29 +1,5 @@
 {
   "type": "array",
   "required": ["children"],
-  "items": {
-    "type": "object",
-    "required": [
-      "active",
-      "ccms_id",
-      "created_at",
-      "date_of_birth",
-      "full_name",
-      "id",
-      "slug",
-      "updated_at",
-      "user_id"
-    ],
-    "properties": {
-      "active": { "type": "boolean" },
-      "ccms_id": { "type": "string" },
-      "created_at": { "type": "string", "format": "date-time" },
-      "date_of_birth": { "type": "string", "format": "date" },
-      "id": { "type": "string" },
-      "full_name": { "type": "string" },
-      "slug": { "type": "string" },
-      "updated_at": { "type": "string", "format": "date-time" },
-      "user_id": { "type": "string", "format": "uuid" }
-    }
-  }
+  "items": {"$ref":"child.json"}
 }

--- a/spec/support/api/schemas/site.json
+++ b/spec/support/api/schemas/site.json
@@ -1,6 +1,7 @@
 {
   "type": "object",
   "required": [
+    "active",
     "created_at",
     "id",
     "name",

--- a/spec/support/api/schemas/sites.json
+++ b/spec/support/api/schemas/sites.json
@@ -1,35 +1,5 @@
 {
   "type": "array",
   "required": ["sites"],
-  "items": {
-    "type": "object",
-    "required": [
-      "created_at",
-      "id",
-      "name",
-      "slug",
-      "updated_at",
-      "business_id",
-      "address",
-      "city",
-      "state",
-      "zip",
-      "county"
-    ],
-    "properties": {
-      "active": { "type": "boolean" },
-      "created_at": { "type": "string", "format": "date-time" },
-      "id": { "type": "string", "format": "uuid" },
-      "name": { "type": "string" },
-      "slug": { "type": "string" },
-      "updated_at": { "type": "string", "format": "date-time" },
-      "business_id": { "type": "string", "format": "uuid" },
-      "address": { "type": "string" },
-      "city": { "type": "string" },
-      "state": { "type": "string" },
-      "zip": { "type": "string" },
-      "county": { "type": "string" },
-      "qris_rating": { "type": "string" }
-    }
-  }
+  "items": {"$ref":"site.json"}
 }

--- a/spec/support/api/schemas/user.json
+++ b/spec/support/api/schemas/user.json
@@ -1,12 +1,12 @@
 {
   "type": "object",
   "required": [
-    "created_at",
-    "id",
     "active",
+    "created_at",
     "email",
     "full_name",
     "greeting_name",
+    "id",
     "language",
     "opt_in_email",
     "opt_in_phone",
@@ -20,12 +20,12 @@
     "updated_at"
   ],
   "properties": {
-    "created_at": { "type": "string", "format": "date-time" },
-    "id": { "type": "string" },
     "active": { "type": "boolean" },
+    "created_at": { "type": "string", "format": "date-time" },
     "email": { "type": "string" },
     "full_name": { "type": "string" },
     "greeting_name": { "type": "string" },
+    "id": { "type": "string" },
     "language": { "type": "string" },
     "opt_in_email": { "type": "boolean" },
     "opt_in_phone": { "type": "boolean" },

--- a/spec/support/api/schemas/user_with_businesses.json
+++ b/spec/support/api/schemas/user_with_businesses.json
@@ -1,68 +1,14 @@
 {
-  "type": "object",
-  "required": [
-    "active",
-    "businesses",
-    "created_at",
-    "email",
-    "full_name",
-    "greeting_name",
-    "id",
-    "language",
-    "opt_in_email",
-    "opt_in_phone",
-    "opt_in_text",
-    "organization",
-    "phone_number",
-    "phone_type",
-    "service_agreement_accepted",
-    "slug",
-    "timezone",
-    "updated_at"
-  ],
-  "properties": {
-    "active": { "type": "boolean" },
-    "businesses": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "active",
-          "category",
-          "created_at",
-          "id",
-          "name",
-          "slug",
-          "updated_at",
-          "user_id"
-        ],
-        "properties": {
-          "active": { "type": "boolean" },
-          "category": { "type": "string" },
-          "created_at": { "type": "string", "format": "date-time" },
-          "id": { "type": "string" },
-          "name": { "type": "string" },
-          "slug": { "type": "string" },
-          "updated_at": { "type": "string", "format": "date-time" },
-          "user_id": { "type": "string", "format": "uuid" }
-        }
+  "allOf": [
+    {"$ref": "user.json"},
+    {
+      "properties": {
+        "businesses": {
+          "type": "array",
+          "items": { "$ref": "business.json" }
+        },
+        "required": ["businesses"]
       }
-    },
-    "created_at": { "type": "string", "format": "date-time" },
-    "email": { "type": "string" },
-    "full_name": { "type": "string" },
-    "greeting_name": { "type": "string" },
-    "id": { "type": "string" },
-    "language": { "type": "string" },
-    "opt_in_email": { "type": "boolean" },
-    "opt_in_phone": { "type": "boolean" },
-    "opt_in_text": { "type": "boolean" },
-    "organization": { "type": "string" },
-    "phone_number": { "type": "string" },
-    "phone_type": { "type": "string" },
-    "service_agreement_accepted": { "type": "boolean" },
-    "slug": { "type": "string" },
-    "timezone": { "type": "string" },
-    "updated_at": { "type": "string", "format": "date-time" }
-  }
+    }
+  ]
 }

--- a/spec/support/api/schemas/user_with_children.json
+++ b/spec/support/api/schemas/user_with_children.json
@@ -1,70 +1,15 @@
 {
-  "type": "object",
-  "required": [
-    "active",
-    "children",
-    "created_at",
-    "email",
-    "full_name",
-    "greeting_name",
-    "id",
-    "language",
-    "opt_in_email",
-    "opt_in_phone",
-    "opt_in_text",
-    "organization",
-    "phone_number",
-    "phone_type",
-    "service_agreement_accepted",
-    "slug",
-    "timezone",
-    "updated_at"
-  ],
-  "properties": {
-    "active": { "type": "boolean" },
-    "children": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "active",
-          "ccms_id",
-          "created_at",
-          "date_of_birth",
-          "full_name",
-          "id",
-          "slug",
-          "updated_at",
-          "user_id"
-        ],
-        "properties": {
-          "active": { "type": "boolean" },
-          "ccms_id": { "type": "string" },
-          "created_at": { "type": "string", "format": "date-time" },
-          "date_of_birth": { "type": "string", "format": "date" },
-          "id": { "type": "string" },
-          "full_name": { "type": "string" },
-          "slug": { "type": "string" },
-          "updated_at": { "type": "string", "format": "date-time" },
-          "user_id": { "type": "string", "format": "uuid" }
-        }
+  "allOf": [
+    {"$ref": "user.json"},
+    {
+      "properties": {
+        "children": {
+          "type": "array",
+          "items": { "$ref": "child.json" }
+        },
+        "required": ["children"]
       }
-    },
-    "created_at": { "type": "string", "format": "date-time" },
-    "email": { "type": "string" },
-    "full_name": { "type": "string" },
-    "greeting_name": { "type": "string" },
-    "id": { "type": "string" },
-    "language": { "type": "string" },
-    "opt_in_email": { "type": "boolean" },
-    "opt_in_phone": { "type": "boolean" },
-    "opt_in_text": { "type": "boolean" },
-    "organization": { "type": "string" },
-    "phone_number": { "type": "string" },
-    "phone_type": { "type": "string" },
-    "service_agreement_accepted": { "type": "boolean" },
-    "slug": { "type": "string" },
-    "timezone": { "type": "string" },
-    "updated_at": { "type": "string", "format": "date-time" }
-  }
+    }
+  ]
 }
+

--- a/spec/support/api/schemas/users.json
+++ b/spec/support/api/schemas/users.json
@@ -1,45 +1,5 @@
 {
   "type": "array",
   "required": ["users"],
-  "items": {
-    "type": "object",
-    "required": [
-      "created_at",
-      "id",
-      "active",
-      "email",
-      "full_name",
-      "greeting_name",
-      "language",
-      "opt_in_email",
-      "opt_in_phone",
-      "opt_in_text",
-      "organization",
-      "phone_number",
-      "phone_type",
-      "service_agreement_accepted",
-      "slug",
-      "timezone",
-      "updated_at"
-    ],
-    "properties": {
-      "created_at": { "type": "string", "format": "date-time" },
-      "id": { "type": "string" },
-      "active": { "type": "boolean" },
-      "email": { "type": "string" },
-      "full_name": { "type": "string" },
-      "greeting_name": { "type": "string" },
-      "language": { "type": "string" },
-      "opt_in_email": { "type": "boolean" },
-      "opt_in_phone": { "type": "boolean" },
-      "opt_in_text": { "type": "boolean" },
-      "organization": { "type": "string" },
-      "phone_number": { "type": "string" },
-      "phone_type": { "type": "string" },
-      "service_agreement_accepted": { "type": "boolean" },
-      "slug": { "type": "string" },
-      "timezone": { "type": "string" },
-      "updated_at": { "type": "string", "format": "date-time" }
-    }
-  }
+  "items": { "$ref":"user.json" }
 }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -33,6 +33,49 @@ RSpec.configure do |config|
       #   }
       # },
       definitions: {
+        user: {
+          type: :object,
+          properties: {
+            email: { type: :string, example: 'user@user.com' },
+            password: { type: :string, example: 'badPassword123!' },
+            full_name: { type: :string, example: 'Marlee Matlin' },
+            greeting_name: { type: :string, example: 'Marlee' },
+            language: { type: :string, example: 'Farsi' },
+            organization: { type: :string, example: 'Society for the Promotion of Elfish Welfare' },
+            phone_number: { type: :string, example: '888-888-8888' },
+            service_agreement_accepted: { type: :boolean, example: 'true' },
+            timezone: { type: :string, example: 'Eastern Time (US & Canada)' }
+          }
+        },
+        business: {
+          type: :object,
+          properties: {
+            name: { type: :string, example: 'Harlequin Child Care' },
+            category: { type: :string, example: 'license_exempt_home' },
+            active: { type: :boolean, example: 'true' }
+          }
+        },
+        child: {
+          type: :object,
+          properties: {
+            ccms_id: { type: :string, example: '987654321' },
+            date_of_birth: { type: :string, example: '1992-11-01' },
+            full_name: { type: :string, example: 'Sean Flannery' }
+          }
+        },
+        site: {
+          type: :object,
+          properties: {
+            name: { type: :string, example: 'Marberry Educational Center' },
+            address: { type: :string, example: '1100 Marks Ave' },
+            city: { type: :string, example: 'Galesburg' },
+            state: { type: :string, example: 'TX' },
+            zip: { type: :string, example: '54321' },
+            county: { type: :string, example: 'Tigh' },
+            qris_rating: { type: :string, example: '2' },
+            business_id: { type: :uuid, example: '3fa57706-f5bb-4d40-9350-85871f698d55' }
+          }
+        },
         payment: {
           type: :object,
           properties: {
@@ -56,27 +99,20 @@ RSpec.configure do |config|
           type: :object,
           properties: {
             user: {
-              type: :object,
-              properties: {
-                email: { type: :string, example: 'user@user.com' },
-                full_name: { type: :string, example: 'Marlee Matlin' },
-                greeting_name: { type: :string, example: 'Marlee' },
-                language: { type: :string, example: 'Farsi' },
-                organization: { type: :string, example: 'Society for the Promotion of Elfish Welfare' },
-                password: { type: :string, example: 'password1234!' },
-                password_confirmation: { type: :string, example: 'password1234!' },
-                phone_number: { type: :string, example: '888-888-8888' },
-                service_agreement_accepted: { type: :boolean, example: 'true' },
-                timezone: { type: :string, example: 'Central Time (US & Canada)' }
-              },
-              required: %w[
-                email
-                full_name
-                language
-                password
-                password_confirmation
-                service_agreement_accepted
-                timezone
+              allOf: [
+                { '$ref': '#/definitions/user' },
+                {
+                  type: :object,
+                  required: %w[
+                    email
+                    full_name
+                    language
+                    password
+                    password_confirmation
+                    service_agreement_accepted
+                    timezone
+                  ]
+                }
               ]
             }
           }
@@ -85,17 +121,9 @@ RSpec.configure do |config|
           type: :object,
           properties: {
             user: {
-              type: :object,
-              properties: {
-                email: { type: :string, example: 'user@user.com' },
-                full_name: { type: :string, example: 'Marlee Matlin' },
-                greeting_name: { type: :string, example: 'Marlee' },
-                language: { type: :string, example: 'Farsi' },
-                organization: { type: :string, example: 'Society for the Promotion of Elfish Welfare' },
-                phone_number: { type: :string, example: '888-888-8888' },
-                service_agreement_accepted: { type: :boolean, example: 'true' },
-                timezone: { type: :string, example: 'Eastern Time (US & Canada)' }
-              }
+              allOf: [
+                { '$ref': '#/definitions/user' }
+              ]
             }
           }
         },
@@ -103,16 +131,16 @@ RSpec.configure do |config|
           type: :object,
           properties: {
             business: {
-              type: :object,
-              properties: {
-                name: { type: :string, example: 'Harlequin Child Care' },
-                category: { type: :string, example: 'license_exempt_home' },
-                user_id: { type: :uuid, example: '3fa57706-f5bb-4d40-9350-85871f698d55' }
-              },
-              required: %w[
-                name
-                category
-                user_id
+              allOf: [
+                { '$ref': '#/definitions/business' },
+                {
+                  type: :object,
+                  required: %w[
+                    name
+                    category
+                    user_id
+                  ]
+                }
               ]
             }
           }
@@ -121,12 +149,9 @@ RSpec.configure do |config|
           type: :object,
           properties: {
             business: {
-              type: :object,
-              properties: {
-                name: { type: :string, example: 'Harlequin Child Care' },
-                category: { type: :string, example: 'license_exempt_home' },
-                active: { type: :boolean, example: 'true' }
-              }
+              allOf: [
+                { '$ref': '#/definitions/business' }
+              ]
             }
           }
         },
@@ -165,12 +190,9 @@ RSpec.configure do |config|
           type: :object,
           properties: {
             child: {
-              type: :object,
-              properties: {
-                ccms_id: { type: :string, example: '987654321' },
-                date_of_birth: { type: :string, example: '1992-11-01' },
-                full_name: { type: :string, example: 'Sean Flannery' }
-              }
+              allOf: [
+                { '$ref': '#/definitions/child' }
+              ]
             }
           }
         },
@@ -178,25 +200,20 @@ RSpec.configure do |config|
           type: :object,
           properties: {
             site: {
-              type: :object,
-              properties: {
-                name: { type: :string, example: 'Marberry Educational Center' },
-                address: { type: :string, example: '1100 Marks Ave' },
-                city: { type: :string, example: 'Galesburg' },
-                state: { type: :string, example: 'TX' },
-                zip: { type: :string, example: '54321' },
-                county: { type: :string, example: 'Tigh' },
-                qris_rating: { type: :string, example: '2' },
-                business_id: { type: :uuid, example: '3fa57706-f5bb-4d40-9350-85871f698d55' }
-              },
-              required: %w[
-                name
-                address
-                city
-                state
-                zip
-                county
-                business_id
+              allOf: [
+                { '$ref': '#/definitions/site' },
+                {
+                  type: :object,
+                  required: %w[
+                    name
+                    address
+                    city
+                    state
+                    zip
+                    county
+                    business_id
+                  ]
+                }
               ]
             }
           }
@@ -204,32 +221,34 @@ RSpec.configure do |config|
         updateSite: {
           type: :object,
           properties: {
-            site: {
-              type: :object,
-              properties: {
-                name: { type: :string, example: 'Marberry Educational Center' },
-                address: { type: :string, example: '1100 Marks Ave' },
-                city: { type: :string, example: 'Galesburg' },
-                state: { type: :string, example: 'TX' },
-                zip: { type: :string, example: '54321' },
-                county: { type: :string, example: 'Tigh' },
-                qris_rating: { type: :string, example: '2' },
-                business_id: { type: :uuid, example: '3fa57706-f5bb-4d40-9350-85871f698d55' }
-              }
+            site: { '$ref': '#/definitions/site' }
+          }
+        },
+        createPayment: {
+          type: :object,
+          properties: {
+            payment: {
+              allOf: [
+                { '$ref': '#/definitions/payment' },
+                {
+                  type: :object,
+                  required: %w[agency_id site_id amount_cents care_finished_on care_started_on paid_on]
+                }
+              ]
+            }
+          }
+        },
+        updatePayment: {
+          type: :object,
+          properties: {
+            payment: {
+              allOf: [
+                { '$ref': '#/definitions/payment' }
+              ]
             }
           }
         }
-      },
-      createPayment: {
-        allOf: [
-          { '$ref': '#/definitions/payment' },
-          {
-            type: :object,
-            required: %w[agency_id site_id amount_cents care_finished_on care_started_on paid_on]
-          }
-        ]
-      },
-      updatePayment: { '$ref': '#/definitions/payment' }
+      }
     }
   }
 

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -975,6 +975,118 @@
     }
   },
   "definitions": {
+    "user": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "example": "user@user.com"
+        },
+        "password": {
+          "type": "string",
+          "example": "badPassword123!"
+        },
+        "full_name": {
+          "type": "string",
+          "example": "Marlee Matlin"
+        },
+        "greeting_name": {
+          "type": "string",
+          "example": "Marlee"
+        },
+        "language": {
+          "type": "string",
+          "example": "Farsi"
+        },
+        "organization": {
+          "type": "string",
+          "example": "Society for the Promotion of Elfish Welfare"
+        },
+        "phone_number": {
+          "type": "string",
+          "example": "888-888-8888"
+        },
+        "service_agreement_accepted": {
+          "type": "boolean",
+          "example": "true"
+        },
+        "timezone": {
+          "type": "string",
+          "example": "Eastern Time (US & Canada)"
+        }
+      }
+    },
+    "business": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "Harlequin Child Care"
+        },
+        "category": {
+          "type": "string",
+          "example": "license_exempt_home"
+        },
+        "active": {
+          "type": "boolean",
+          "example": "true"
+        }
+      }
+    },
+    "child": {
+      "type": "object",
+      "properties": {
+        "ccms_id": {
+          "type": "string",
+          "example": "987654321"
+        },
+        "date_of_birth": {
+          "type": "string",
+          "example": "1992-11-01"
+        },
+        "full_name": {
+          "type": "string",
+          "example": "Sean Flannery"
+        }
+      }
+    },
+    "site": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "Marberry Educational Center"
+        },
+        "address": {
+          "type": "string",
+          "example": "1100 Marks Ave"
+        },
+        "city": {
+          "type": "string",
+          "example": "Galesburg"
+        },
+        "state": {
+          "type": "string",
+          "example": "TX"
+        },
+        "zip": {
+          "type": "string",
+          "example": "54321"
+        },
+        "county": {
+          "type": "string",
+          "example": "Tigh"
+        },
+        "qris_rating": {
+          "type": "string",
+          "example": "2"
+        },
+        "business_id": {
+          "type": "uuid",
+          "example": "3fa57706-f5bb-4d40-9350-85871f698d55"
+        }
+      }
+    },
     "payment": {
       "type": "object",
       "properties": {
@@ -1028,57 +1140,22 @@
       "type": "object",
       "properties": {
         "user": {
-          "type": "object",
-          "properties": {
-            "email": {
-              "type": "string",
-              "example": "user@user.com"
+          "allOf": [
+            {
+              "$ref": "#/definitions/user"
             },
-            "full_name": {
-              "type": "string",
-              "example": "Marlee Matlin"
-            },
-            "greeting_name": {
-              "type": "string",
-              "example": "Marlee"
-            },
-            "language": {
-              "type": "string",
-              "example": "Farsi"
-            },
-            "organization": {
-              "type": "string",
-              "example": "Society for the Promotion of Elfish Welfare"
-            },
-            "password": {
-              "type": "string",
-              "example": "password1234!"
-            },
-            "password_confirmation": {
-              "type": "string",
-              "example": "password1234!"
-            },
-            "phone_number": {
-              "type": "string",
-              "example": "888-888-8888"
-            },
-            "service_agreement_accepted": {
-              "type": "boolean",
-              "example": "true"
-            },
-            "timezone": {
-              "type": "string",
-              "example": "Central Time (US & Canada)"
+            {
+              "type": "object",
+              "required": [
+                "email",
+                "full_name",
+                "language",
+                "password",
+                "password_confirmation",
+                "service_agreement_accepted",
+                "timezone"
+              ]
             }
-          },
-          "required": [
-            "email",
-            "full_name",
-            "language",
-            "password",
-            "password_confirmation",
-            "service_agreement_accepted",
-            "timezone"
           ]
         }
       }
@@ -1087,41 +1164,11 @@
       "type": "object",
       "properties": {
         "user": {
-          "type": "object",
-          "properties": {
-            "email": {
-              "type": "string",
-              "example": "user@user.com"
-            },
-            "full_name": {
-              "type": "string",
-              "example": "Marlee Matlin"
-            },
-            "greeting_name": {
-              "type": "string",
-              "example": "Marlee"
-            },
-            "language": {
-              "type": "string",
-              "example": "Farsi"
-            },
-            "organization": {
-              "type": "string",
-              "example": "Society for the Promotion of Elfish Welfare"
-            },
-            "phone_number": {
-              "type": "string",
-              "example": "888-888-8888"
-            },
-            "service_agreement_accepted": {
-              "type": "boolean",
-              "example": "true"
-            },
-            "timezone": {
-              "type": "string",
-              "example": "Eastern Time (US & Canada)"
+          "allOf": [
+            {
+              "$ref": "#/definitions/user"
             }
-          }
+          ]
         }
       }
     },
@@ -1129,25 +1176,18 @@
       "type": "object",
       "properties": {
         "business": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string",
-              "example": "Harlequin Child Care"
+          "allOf": [
+            {
+              "$ref": "#/definitions/business"
             },
-            "category": {
-              "type": "string",
-              "example": "license_exempt_home"
-            },
-            "user_id": {
-              "type": "uuid",
-              "example": "3fa57706-f5bb-4d40-9350-85871f698d55"
+            {
+              "type": "object",
+              "required": [
+                "name",
+                "category",
+                "user_id"
+              ]
             }
-          },
-          "required": [
-            "name",
-            "category",
-            "user_id"
           ]
         }
       }
@@ -1156,21 +1196,11 @@
       "type": "object",
       "properties": {
         "business": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string",
-              "example": "Harlequin Child Care"
-            },
-            "category": {
-              "type": "string",
-              "example": "license_exempt_home"
-            },
-            "active": {
-              "type": "boolean",
-              "example": "true"
+          "allOf": [
+            {
+              "$ref": "#/definitions/business"
             }
-          }
+          ]
         }
       }
     },
@@ -1232,21 +1262,11 @@
       "type": "object",
       "properties": {
         "child": {
-          "type": "object",
-          "properties": {
-            "ccms_id": {
-              "type": "string",
-              "example": "987654321"
-            },
-            "date_of_birth": {
-              "type": "string",
-              "example": "1992-11-01"
-            },
-            "full_name": {
-              "type": "string",
-              "example": "Sean Flannery"
+          "allOf": [
+            {
+              "$ref": "#/definitions/child"
             }
-          }
+          ]
         }
       }
     },
@@ -1254,49 +1274,22 @@
       "type": "object",
       "properties": {
         "site": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string",
-              "example": "Marberry Educational Center"
+          "allOf": [
+            {
+              "$ref": "#/definitions/site"
             },
-            "address": {
-              "type": "string",
-              "example": "1100 Marks Ave"
-            },
-            "city": {
-              "type": "string",
-              "example": "Galesburg"
-            },
-            "state": {
-              "type": "string",
-              "example": "TX"
-            },
-            "zip": {
-              "type": "string",
-              "example": "54321"
-            },
-            "county": {
-              "type": "string",
-              "example": "Tigh"
-            },
-            "qris_rating": {
-              "type": "string",
-              "example": "2"
-            },
-            "business_id": {
-              "type": "uuid",
-              "example": "3fa57706-f5bb-4d40-9350-85871f698d55"
+            {
+              "type": "object",
+              "required": [
+                "name",
+                "address",
+                "city",
+                "state",
+                "zip",
+                "county",
+                "business_id"
+              ]
             }
-          },
-          "required": [
-            "name",
-            "address",
-            "city",
-            "state",
-            "zip",
-            "county",
-            "business_id"
           ]
         }
       }
@@ -1305,64 +1298,44 @@
       "type": "object",
       "properties": {
         "site": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string",
-              "example": "Marberry Educational Center"
+          "$ref": "#/definitions/site"
+        }
+      }
+    },
+    "createPayment": {
+      "type": "object",
+      "properties": {
+        "payment": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/payment"
             },
-            "address": {
-              "type": "string",
-              "example": "1100 Marks Ave"
-            },
-            "city": {
-              "type": "string",
-              "example": "Galesburg"
-            },
-            "state": {
-              "type": "string",
-              "example": "TX"
-            },
-            "zip": {
-              "type": "string",
-              "example": "54321"
-            },
-            "county": {
-              "type": "string",
-              "example": "Tigh"
-            },
-            "qris_rating": {
-              "type": "string",
-              "example": "2"
-            },
-            "business_id": {
-              "type": "uuid",
-              "example": "3fa57706-f5bb-4d40-9350-85871f698d55"
+            {
+              "type": "object",
+              "required": [
+                "agency_id",
+                "site_id",
+                "amount_cents",
+                "care_finished_on",
+                "care_started_on",
+                "paid_on"
+              ]
             }
-          }
+          ]
+        }
+      }
+    },
+    "updatePayment": {
+      "type": "object",
+      "properties": {
+        "payment": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/payment"
+            }
+          ]
         }
       }
     }
-  },
-  "createPayment": {
-    "allOf": [
-      {
-        "$ref": "#/definitions/payment"
-      },
-      {
-        "type": "object",
-        "required": [
-          "agency_id",
-          "site_id",
-          "amount_cents",
-          "care_finished_on",
-          "care_started_on",
-          "paid_on"
-        ]
-      }
-    ]
-  },
-  "updatePayment": {
-    "$ref": "#/definitions/payment"
   }
 }


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->
fixes #198 

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [x] Did you run `rails rswag` from the root?
* [x] Did you run `rubocop` from the root?
* [ ] Did you run `yarn lint` in `/client`?
* [ ] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->

I added "active" as a required parameter to both `agency.json` and `site.json`.  Previously, the plurals of those (`agencies.json` and `sites.json`) had "active" as required, but the singular versions did not.  (IOW: discrepancy).

I spent waaaay too many hours trying to figure out a reasonable way to have the definitions in  `swagger_helper`  refer to the `.json` files in `spec/support/api/schemas'.  But couldn't make it happen.  (That way we'd only have 1 schema defined for each model, instead of having it defined once in a .json file _and_ in swagger_helper.rb.)
At least now I have a deep understanding of what rswag is doing.

