### PR TITLE
Improve signup error handling

### DIFF
--- a/client/src/i18n/locales/en/index.json
+++ b/client/src/i18n/locales/en/index.json
@@ -59,5 +59,7 @@
   "gettingStartedWelcome": "Welcome to Pie for Providers, ",
   "gettingStartedTitle": "Let's Get Started",
   "gettingStartedInstructions": "Follow these instructions to set up your case dashboard. This should take about 15 minutes, and you'll only have to do this once. Get ready to increase your slice of the pie!",
-  "gettingStartedButton": "Get Started"
+  "gettingStartedButton": "Get Started",
+
+  "genericErrorMessage": "Something went wrong, try again later."
 }

--- a/client/src/i18n/locales/es/index.json
+++ b/client/src/i18n/locales/es/index.json
@@ -61,5 +61,5 @@
   "gettingStartedInstructions": "Sigue estas instrucciones para configurar tu panel de caso. Esto debería tardar unos 15 minutos y solo tendrás que hacerlo una vez. ¡Prepárate para aumentar su porción del pastel!",
   "gettingStartedButton": "Comienza",
 
-  "genericErrorMessage": "Something went wrong, try again later."
+  "genericErrorMessage": "Algo salió mal, inténtalo de nuevo más tarde."
 }

--- a/client/src/i18n/locales/es/index.json
+++ b/client/src/i18n/locales/es/index.json
@@ -59,5 +59,7 @@
   "gettingStartedWelcome": "Bienvenidas a Pie for Providers, ",
   "gettingStartedTitle": "Comencemos",
   "gettingStartedInstructions": "Sigue estas instrucciones para configurar tu panel de caso. Esto debería tardar unos 15 minutos y solo tendrás que hacerlo una vez. ¡Prepárate para aumentar su porción del pastel!",
-  "gettingStartedButton": "Comienza"
+  "gettingStartedButton": "Comienza",
+
+  "genericErrorMessage": "Something went wrong, try again later."
 }


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

- Only sets validation errors if the response status is 422
- Introduces a new state for non-validation errors to capture 500 responses from the server and displays a generic error message.
- Resets the error state before submitting the form

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `rails rswag` from the root?
* [ ] Did you run `rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

Sign up with an existing phone number or email and you should find the error message show up.

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
