### PR TITLE
Inherit Site and ChildSite models from UuidApplicationRecord

### DIFF
--- a/app/models/child_site.rb
+++ b/app/models/child_site.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 # The sites where a child receives care
-class ChildSite < ApplicationRecord
-  # Handles UUIDs breaking ActiveRecord's usual ".first" and ".last" behavior
-  self.implicit_order_column = 'created_at'
-
+class ChildSite < UuidApplicationRecord
   belongs_to :child
   belongs_to :site
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 # The sites at which businesses have children in care
-class Site < ApplicationRecord
-  # Handles UUIDs breaking ActiveRecord's usual ".first" and ".last" behavior
-  self.implicit_order_column = 'created_at'
-
+class Site < UuidApplicationRecord
   belongs_to :business
   has_many :child_sites, dependent: :destroy
   has_many :children, through: :child_sites


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

Removes the `implicit_order_column` setting from `Site` and `ChildSite` models by inheriting from `UuidApplicationRecord`.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `rails rswag` from the root?
* [x] Did you run `rubocop` from the root?
* [ ] Did you run `yarn lint` in `/client`?
* [ ] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
