### PR TITLE
Move development-specific config from application config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,17 +36,5 @@ module App
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
-
-    if Rails.env.development?
-      config.generators do |g|
-        g.test_framework :rspec,
-                         fixtures: true,
-                         view_specs: false,
-                         helper_specs: true,
-                         routing_specs: false,
-                         controller_specs: false,
-                         request_specs: true
-      end
-    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,4 +59,14 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.generators do |g|
+    g.test_framework :rspec,
+                     fixtures: true,
+                     view_specs: false,
+                     helper_specs: true,
+                     routing_specs: false,
+                     controller_specs: false,
+                     request_specs: true
+  end
 end


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

Moves development environment-specific config from `config/application` to `config/environments/application.rb`

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `rails rswag` from the root?
* [x] Did you run `rubocop` from the root?
* [ ] Did you run `yarn lint` in `/client`?
* [ ] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
