### PR TITLE
Allow users to log out

### DIFF
--- a/client/src/_shared/LoggedInLayout.js
+++ b/client/src/_shared/LoggedInLayout.js
@@ -1,12 +1,20 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { useHistory } from 'react-router-dom'
 import pieSliceLogo from '_assets/pieSliceLogo.svg'
-import { Breadcrumb } from 'antd'
+import { Breadcrumb, Button } from 'antd'
 import '_assets/styles/layouts.css'
 import { useTranslation } from 'react-i18next'
 
 export function LoggedInLayout({ children, title }) {
   const { t } = useTranslation()
+  const history = useHistory()
+
+  const logout = () => {
+    localStorage.removeItem('pie-token')
+    history.push('/login')
+  }
+
   return (
     <>
       <div className="w-full shadow p-4 flex items-center">
@@ -18,7 +26,9 @@ export function LoggedInLayout({ children, title }) {
         <div className="text-2xl font-semibold flex-grow">
           Pie for Providers
         </div>
-        <div>{t('logout')}</div>
+        <Button type="link" onClick={logout}>
+          {t('logout')}
+        </Button>
       </div>
       <div className="w-full sm:h-full bg-mediumGray p-4">
         {title && (


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

When the user clicks on the **Log Out** link, the token in `localStorage` is removed and the user is redirected to `/login`.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `rails rswag` from the root?
* [ ] Did you run `rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
1. Log in.
2. Click on the **Log Out** link on the top right. You should be taken back to `/login`.

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
