### PR TITLE
Internationalize pages

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,8 +16,11 @@ import ErrorBoundary from './ErrorBoundary'
 import CasesImport from './CasesImport'
 import { AuthLayout } from '_shared'
 import { isUserLoggedIn } from '_utils'
+import { useTranslation } from 'react-i18next'
 
 const App = () => {
+  const { t } = useTranslation()
+
   useEffect(() => {
     /* skip production code for coverage */
     /* istanbul ignore next */
@@ -43,7 +46,7 @@ const App = () => {
                 contentComponent={Login}
               />
             </Route>
-            <AuthorizedRoute exact path="/getting-started" title="Setup">
+            <AuthorizedRoute exact path="/getting-started" title={t('setup')}>
               <GettingStarted />
             </AuthorizedRoute>
             <AuthorizedRoute exact path="/dashboard">

--- a/client/src/CasesImport/CasesImport.js
+++ b/client/src/CasesImport/CasesImport.js
@@ -1,14 +1,18 @@
 import React, { useState } from 'react'
 import { Alert, Typography } from 'antd'
 import { sha1 } from 'hash-anything'
+import { useTranslation } from 'react-i18next'
 import { CasesImportReview } from './CasesImportReview'
-import { parserTypes, columns } from './utils'
+import { parserTypes, getColumns } from './utils'
 
 const { Title } = Typography
 
 export function CasesImport() {
   const [kids, setKids] = useState([])
   const [error, setError] = useState('')
+  const { t } = useTranslation()
+
+  const columns = getColumns(t)
 
   const onFileChange = e => {
     setError('')
@@ -17,7 +21,7 @@ export function CasesImport() {
     const { type } = file
     if (!(type in parserTypes)) {
       setKids([])
-      setError('Invalid file format. Supported formats: CSV, XLS, and XLSX')
+      setError(t('uploadCasesInvalidFileFormat'))
       return
     }
 
@@ -56,7 +60,7 @@ export function CasesImport() {
 
   return (
     <div>
-      <Title>Upload Cases</Title>
+      <Title>{t('uploadCases')}</Title>
       {error && (
         <Alert
           message={error}

--- a/client/src/CasesImport/CasesImportReview.js
+++ b/client/src/CasesImport/CasesImportReview.js
@@ -1,16 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Table } from 'antd'
-import { columns } from './utils'
+import { useTranslation } from 'react-i18next'
+import { getColumns } from './utils'
 
 export function CasesImportReview({ kids }) {
+  const { t } = useTranslation()
+
   return (
     <div>
-      <h1 className="sr-only">Review Imported Cases</h1>
+      <h1 className="sr-only">{t('reviewImportedCases')}</h1>
       {kids.length > 0 && (
         <Table
           dataSource={kids}
-          columns={columns}
+          columns={getColumns(t)}
           style={{ marginTop: '16px' }}
         />
       )}

--- a/client/src/CasesImport/utils.js
+++ b/client/src/CasesImport/utils.js
@@ -31,75 +31,75 @@ export const parserTypes = {
   'application/vnd.ms-excel': parsers.xlsx
 }
 
-export const columns = [
+export const getColumns = t => [
   {
     dataIndex: 'firstName',
     key: 'firstName',
-    title: 'First Name'
+    title: t('firstName')
   },
   {
     dataIndex: 'lastName',
     key: 'lastName',
-    title: 'Last Name'
+    title: t('lastName')
   },
   {
     dataIndex: 'dateOfBirth',
     key: 'dateOfBirth',
-    title: 'Date of birth',
+    title: t('dateOfBirth'),
     render: text => XLSX.SSF.format('yyyy-mm-dd', text)
   },
   {
     dataIndex: 'siteId',
     key: 'siteId',
-    title: 'Site',
+    title: t('siteId'),
     responsive: ['sm']
   },
   {
     dataIndex: 'caseStatus',
     key: 'caseStatus',
-    title: 'Case Status',
+    title: t('caseStatus'),
     responsive: ['sm']
   },
   {
     dataIndex: 'caseNumber',
     key: 'caseNumber',
-    title: 'Case Number',
+    title: t('caseNumber'),
     responsive: ['sm']
   },
   {
     dataIndex: 'fullDaysPerMonth',
     key: 'fullDaysPerMonth',
-    title: 'Full days (per month)',
+    title: t('fullDaysPerMonth'),
     responsive: ['md']
   },
   {
     dataIndex: 'partDaysPerMonth',
     key: 'partDaysPerMonth',
-    title: 'Part days (per month)',
+    title: t('partDaysPerMonth'),
     responsive: ['md']
   },
   {
     dataIndex: 'effectiveOn',
     key: 'effectiveOn',
-    title: 'Effective On',
+    title: t('effectiveOn'),
     responsive: ['md']
   },
   {
     dataIndex: 'expiresOn',
     key: 'expiresOn',
-    title: 'Expires on',
+    title: t('expiresOn'),
     responsive: ['md']
   },
   {
     dataIndex: 'copay',
     key: 'copay',
-    title: 'Co-pay',
+    title: t('copay'),
     responsive: ['lg']
   },
   {
     dataIndex: 'copayFrequency',
     key: 'copayFrequency',
-    title: 'Co-pay frequency',
+    title: t('copayFrequency'),
     responsive: ['lg']
   }
 ]

--- a/client/src/Dashboard/Dashboard.js
+++ b/client/src/Dashboard/Dashboard.js
@@ -1,9 +1,12 @@
 import React, { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useApiResponse } from '_shared/_hooks/useApiResponse'
 
 export function Dashboard() {
   const [businessList, setBusinessList] = useState([])
   const { makeRequest } = useApiResponse()
+  const { t } = useTranslation()
+
   useEffect(() => {
     const responseValue = async () => {
       const businesses = await makeRequest({
@@ -30,7 +33,7 @@ export function Dashboard() {
 
   return (
     <div className="dashboard">
-      <h1>This is the dashboard</h1>
+      <h1>{t('dashboardTitle')}</h1>
       {businessList &&
         businessList.map(business => {
           return <div key={business.name}>{business.name}</div>

--- a/client/src/ErrorBoundary/ErrorBoundary.js
+++ b/client/src/ErrorBoundary/ErrorBoundary.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import * as Sentry from '@sentry/browser'
-// TODO internationalization on "report feedback" button
+import { withTranslation } from 'react-i18next'
 
-export class ErrorBoundary extends Component {
+class ErrorBoundary extends Component {
   constructor(props) {
     super(props)
     this.state = { eventId: null }
@@ -24,6 +24,8 @@ export class ErrorBoundary extends Component {
   }
 
   render() {
+    const { t } = this.props
+
     if (this.state.hasError) {
       // TODO: add some language here for error handling for users
       return (
@@ -33,7 +35,7 @@ export class ErrorBoundary extends Component {
             Sentry.showReportDialog({ eventId: this.state.eventId })
           }
         >
-          Report Feedback
+          {t('reportFeedback')}
         </button>
       )
     }
@@ -43,5 +45,8 @@ export class ErrorBoundary extends Component {
 }
 
 ErrorBoundary.propTypes = {
+  t: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired
 }
+
+export const ErrorBoundaryComponent = withTranslation()(ErrorBoundary)

--- a/client/src/ErrorBoundary/index.js
+++ b/client/src/ErrorBoundary/index.js
@@ -1,1 +1,1 @@
-export { ErrorBoundary as default } from './ErrorBoundary'
+export { ErrorBoundaryComponent as default } from './ErrorBoundary'

--- a/client/src/GettingStarted/GettingStarted.js
+++ b/client/src/GettingStarted/GettingStarted.js
@@ -52,7 +52,7 @@ export function GettingStarted() {
           <p>{t('gettingStartedInstructions')}</p>
         </div>
 
-        <Typography.Title level={3}>Steps</Typography.Title>
+        <Typography.Title level={3}>{t('steps')}</Typography.Title>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mx-4">
           {cards.map((card, idx) => (
             <Card

--- a/client/src/Login/Login.js
+++ b/client/src/Login/Login.js
@@ -41,7 +41,7 @@ export function Login() {
         <Link to="/signup" className="uppercase">
           {t('signup')}
         </Link>{' '}
-        or <span className="uppercase font-bold">{t('login')}</span>
+        {t('or')} <span className="uppercase font-bold">{t('login')}</span>
       </p>
 
       {apiError && (

--- a/client/src/NotFound.js
+++ b/client/src/NotFound.js
@@ -1,11 +1,14 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 
 function NotFound() {
+  const { t } = useTranslation()
+
   return (
     <div className="four-oh-four">
-      <h1>404: Not found</h1>
-      <Link to="/">Back home</Link>
+      <h1>{t('notFound')}</h1>
+      <Link to="/">{t('goBackHome')}</Link>
     </div>
   )
 }

--- a/client/src/Signup/Confirmation.js
+++ b/client/src/Signup/Confirmation.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { useTranslation } from 'react-i18next'
 import { Divider, Typography } from 'antd'
 import LabelImportantIcon from '@material-ui/icons/LabelImportant'
 
@@ -24,33 +25,33 @@ ListItem.propTypes = {
 }
 
 const Confirmation = ({ userEmail }) => {
+  const { t } = useTranslation()
+
   return (
     <>
-      <Title className="text-center">Thanks for signing up!</Title>
+      <Title className="text-center">{t('signupThanks')}</Title>
       <Title level={3} className="text-center">
-        We’ve sent you an email to verify your account.
+        {t('emailVerificationText')}
       </Title>
       <Divider />
       <div className="text-left">
         <div className="mb-2">
-          <Text>{"Didn't receive the email?"}</Text>
+          <Text>{t('emailNotReceived')}</Text>
         </div>
         <ListItem>
-          <Text>
-            Is {userEmail} your correct email without typos? If not, you can
-            restart the signup process.
-          </Text>
+          <Text>{t('restartSignup', { userEmail })}</Text>
         </ListItem>
         <ListItem>
-          <Text>Check your spam folder</Text>
+          <Text>{t('checkSpam')}</Text>
         </ListItem>
         <ListItem>
           <Text>
-            Add <Text underline={true}>{pieEmail}</Text> to your contacts.
+            {t('add')} <Text underline={true}>{pieEmail}</Text>{' '}
+            {t('addToContacts')}
           </Text>
         </ListItem>
         <ListItem>
-          <Link to="#">Click here to resend the email.</Link>
+          <Link to="#">{t('resendConfirmationEmail')}</Link>
         </ListItem>
       </div>
     </>

--- a/client/src/i18n/index.js
+++ b/client/src/i18n/index.js
@@ -21,6 +21,8 @@ i18n
     fallbackLng: 'en',
     supportedLngs: ['en', 'es'],
     interpolation: {
+      prefix: '{',
+      suffix: '}',
       escapeValue: false
     }
   })

--- a/client/src/i18n/locales/en/index.json
+++ b/client/src/i18n/locales/en/index.json
@@ -48,7 +48,19 @@
   "passwordConfirmationMatch": "The two passwords that you entered do not match!",
   "passwordConfirmationPlaceholder": "Confirm your password",
   "termsRequired": "Please read and agree to our Terms of Service",
+  "signupThanks": "Thanks for signing up!",
+  "emailVerificationText": "We’ve sent you an email to verify your account.",
+  "emailNotReceived": "Didn't receive the email?",
+  "restartSignup": "Is {userEmail} your correct email without typos? If not, you can restart the signup process.",
+  "checkSpam": "Check your spam folder",
+  "add": "Add",
+  "addToContacts": "to your contacts.",
+  "resendConfirmationEmail": "Click here to resend the email.",
+
   "reportFeedback": "Report feedback",
+
+  "setup": "Setup",
+  "steps": "Steps",
   "gettingStartedBusinesses": "Tell us about the businesses and sites you manage, so we know which subsidy payment rates to apply to your cases.",
   "gettingStartedBusinessesTitle": "Add your business name",
   "gettingStartedUpload": "Upload a spreadsheet with the names and birthdays of the subsidy-eligible children you serve. In most cases, you can download this from other software you use. This helps us calculate each child's subsidy payment rate.",
@@ -62,5 +74,27 @@
   "gettingStartedInstructions": "Follow these instructions to set up your case dashboard. This should take about 15 minutes, and you'll only have to do this once. Get ready to increase your slice of the pie!",
   "gettingStartedButton": "Get Started",
 
-  "genericErrorMessage": "Something went wrong, try again later."
+  "genericErrorMessage": "Something went wrong, try again later.",
+
+  "uploadCases": "Upload Cases",
+  "uploadCasesInvalidFileFormat": "Invalid file format. Supported formats: CSV, XLS, and XLSX",
+  "reviewImportedCases": "Review Imported Cases",
+
+  "firstName": "First Name",
+  "lastName": "Last Name",
+  "dateOfBirth": "Date of birth",
+  "siteId": "Site",
+  "caseStatus": "Case Status",
+  "caseNumber": "Case Number",
+  "fullDaysPerMonth": "Full days (per month)",
+  "partDaysPerMonth": "Part days (per month)",
+  "effectiveOn": "Effective On",
+  "expiresOn": "Expires on",
+  "copay": "Co-pay",
+  "copayFrequency": "Co-pay frequency",
+
+  "notFound": "404: Not found",
+  "goBackHome": "Back home",
+
+  "dashboardTitle": "This is the dashboard"
 }

--- a/client/src/i18n/locales/es/index.json
+++ b/client/src/i18n/locales/es/index.json
@@ -48,7 +48,19 @@
   "passwordConfirmationMatch": "¡Las dos contraseñas que ingresaste no coinciden!",
   "passwordConfirmationPlaceholder": "Confirma tu contraseña",
   "termsRequired": "Lee y acepta las Condiciones de Uso",
+  "signupThanks": "¡Gracias por registrarse!",
+  "emailVerificationText": "We’ve sent you an email to verify your account.",
+  "emailNotReceived": "Le hemos enviado un correo electrónico para verificar tu cuenta.",
+  "restartSignup": "¿Es {userEmail} tu correo electrónico correcto sin errores de escritura? Si no, puedes reiniciar el proceso de registro",
+  "checkSpam": "Revisa tu carpeta de spam.",
+  "add": "Añade",
+  "addToContacts": "a tus contactos.",
+  "resendConfirmationEmail": "Haga clic aquí para reenviar el correo electrónico.",
+
   "reportFeedback": "Da comentarios",
+
+  "setup": "Configuración",
+  "steps": "Pasos",
   "gettingStartedBusinesses": "Cuéntanos sobre las empresas y los sitios que gestionas, para que sepamos cuales tarifas del subsidio aplican a tus casos",
   "gettingStartedBusinessesTitle": "Agrega el nombre de tu empresa",
   "gettingStartedUpload": "Sube una hoja de cálculo con los nombres y los cumpleaños de los niños calificados para el subsidio bajo tu cuidado. En la mayoría de los casos, puedes descargarla de otro software que utilices. Esto nos ayuda a calcular la tarifa del subsidio de cada niño",
@@ -62,5 +74,27 @@
   "gettingStartedInstructions": "Sigue estas instrucciones para configurar tu pantalla principal de casos. Esto debería tardar unos 15 minutos y solo tendrás que hacerlo una vez. ¡Prepárate para aumentar tu porción del pastel!",
   "gettingStartedButton": "Comienza",
 
-  "genericErrorMessage": "Algo salió mal, inténtalo de nuevo más tarde."
+  "genericErrorMessage": "Algo salió mal, inténtalo de nuevo más tarde.",
+
+  "uploadCases": "Subir los casos",
+  "uploadCasesInvalidFileFormat": "Formato de archivo inválido. Formatos admitidos: CSV, XLS y XLSX",
+  "reviewImportedCases": "Revisar los casos importados",
+
+  "firstName": "Nombre",
+  "lastName": "Apellido",
+  "dateOfBirth": "Fecha de nacimiento",
+  "siteId": "Sitio",
+  "caseStatus": "Estado del caso",
+  "caseNumber": "Número de caso",
+  "fullDaysPerMonth": "Días completos (por mes)",
+  "partDaysPerMonth": "Días parciales (por mes)",
+  "effectiveOn": "Efectivo en",
+  "expiresOn": "Expira en",
+  "copay": "Copago",
+  "copayFrequency": "Frecuencia de copago",
+
+  "notFound": "404: No se encuentra",
+  "goBackHome": "Ir a inicio",
+
+  "dashboardTitle": "Este es el dashboard"
 }


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

#23 #251

Replaces all hard-coded English copy with `t('key')` to support both English and Spanish.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

Visit all the pages and switch the language (you can update the language in `localStorage` — `localStorage.setItem('i18nextLng', 'es')` or use the language switcher on the login and signup pages).

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
