### PR TITLE
Issue 154

### DIFF
--- a/client/src/_shared/LoggedInLayout.js
+++ b/client/src/_shared/LoggedInLayout.js
@@ -2,13 +2,16 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { useHistory } from 'react-router-dom'
 import pieSliceLogo from '_assets/pieSliceLogo.svg'
-import { Breadcrumb, Button } from 'antd'
+import { Breadcrumb, Button, Grid } from 'antd'
 import '_assets/styles/layouts.css'
 import { useTranslation } from 'react-i18next'
+
+const { useBreakpoint } = Grid
 
 export function LoggedInLayout({ children, title }) {
   const { t } = useTranslation()
   const history = useHistory()
+  const screens = useBreakpoint()
 
   const logout = () => {
     localStorage.removeItem('pie-token')
@@ -23,9 +26,11 @@ export function LoggedInLayout({ children, title }) {
           src={pieSliceLogo}
           className="w-8 mr-2"
         />
-        <div className="text-2xl font-semibold flex-grow">
-          Pie for Providers
-        </div>
+        { screens.lg && (
+          <div className="text-2xl font-semibold flex-grow">
+            Pie for Providers
+          </div>
+        )}
         <Button type="link" onClick={logout}>
           {t('logout')}
         </Button>

--- a/client/src/_shared/LoggedInLayout.js
+++ b/client/src/_shared/LoggedInLayout.js
@@ -19,25 +19,23 @@ export function LoggedInLayout({ children, title }) {
   }
 
   return (
-    <>
-      <div className="w-full shadow-md px-4 my-4 flex items-center">
+    <div className="bg-mediumGray">
+      <div className="w-full shadow-md p-4 flex items-center bg-white">
         <img
           alt={t('pieforProvidersLogoAltText')}
           src={pieSliceLogo}
           className="w-8 mr-2"
         />
-        {screens.lg && (
-          <div className="text-2xl font-semibold flex-grow">
-            Pie for Providers
-          </div>
-        )}
+        <div className={`text-2xl font-semibold flex-grow ${screens.lg ? 'visible' : 'invisible'}`}>
+          Pie for Providers
+        </div>
         <Button type="link" onClick={logout}>
           {t('logout')}
         </Button>
       </div>
-      <div className="w-full sm:h-full bg-mediumGray px-4 my-4">
+      <div className="w-full sm:h-full px-4 mt-4">
         {title && (
-          <Breadcrumb className="mb-4">
+          <Breadcrumb className="mb-2">
             <Breadcrumb.Item>{title}</Breadcrumb.Item>
           </Breadcrumb>
         )}
@@ -45,7 +43,7 @@ export function LoggedInLayout({ children, title }) {
           {children}
         </div>
       </div>
-    </>
+    </div>
   )
 }
 

--- a/client/src/_shared/LoggedInLayout.js
+++ b/client/src/_shared/LoggedInLayout.js
@@ -26,7 +26,7 @@ export function LoggedInLayout({ children, title }) {
           src={pieSliceLogo}
           className="w-8 mr-2"
         />
-        { screens.lg && (
+        {screens.lg && (
           <div className="text-2xl font-semibold flex-grow">
             Pie for Providers
           </div>

--- a/client/src/_shared/LoggedInLayout.js
+++ b/client/src/_shared/LoggedInLayout.js
@@ -26,7 +26,11 @@ export function LoggedInLayout({ children, title }) {
           src={pieSliceLogo}
           className="w-8 mr-2"
         />
-        <div className={`text-2xl font-semibold flex-grow ${screens.lg ? 'visible' : 'invisible'}`}>
+        <div
+          className={`text-2xl font-semibold flex-grow ${
+            screens.lg ? 'visible' : 'invisible'
+          }`}
+        >
           Pie for Providers
         </div>
         <Button type="link" onClick={logout}>

--- a/client/src/_shared/LoggedInLayout.js
+++ b/client/src/_shared/LoggedInLayout.js
@@ -20,7 +20,7 @@ export function LoggedInLayout({ children, title }) {
 
   return (
     <>
-      <div className="w-full shadow p-4 flex items-center">
+      <div className="w-full shadow-md px-4 my-4 flex items-center">
         <img
           alt={t('pieforProvidersLogoAltText')}
           src={pieSliceLogo}
@@ -35,13 +35,13 @@ export function LoggedInLayout({ children, title }) {
           {t('logout')}
         </Button>
       </div>
-      <div className="w-full sm:h-full bg-mediumGray p-4">
+      <div className="w-full sm:h-full bg-mediumGray px-4 my-4">
         {title && (
           <Breadcrumb className="mb-4">
             <Breadcrumb.Item>{title}</Breadcrumb.Item>
           </Breadcrumb>
         )}
-        <div className="bg-white px-4 pb-6 pt-8 shadow rounded-sm">
+        <div className="bg-white px-4 pb-6 pt-8 shadow-md rounded-sm">
           {children}
         </div>
       </div>


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

these two issues:
 Pie logo and "Pie for Providers" title on left side
The words "Pie for Providers" should disappear in tablet and mobile, but they do not

Tailwind base shadow for header & main content
the shadows should follow what is here: https://tailwindcss.com/docs/box-shadow#app
but it looks like 1- the header has no shadow
2- the card has the shadow-sm applied to it. it should have the shadow (regular) style applied to it.

from  the qa comments in #154 

![image](https://user-images.githubusercontent.com/1022615/91678865-4f40c080-eb0c-11ea-8904-077faa4980cf.png)

![image](https://user-images.githubusercontent.com/1022615/91678890-5ff13680-eb0c-11ea-8132-3f7a8197d846.png)

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
👀 the `/getting-started` page to see the logged in layout

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
The shadow was using `default` and i bumped it up to `md` from these [default configs](https://github.com/tailwindlabs/tailwindcss/blob/a2956f8a75dec0047764abddc7ca490a2ca4596c/stubs/defaultConfig.stub.js#L203) but we can make that bigger still if you want.