### PR TITLE
Fix service agreement checkbox validation on the Signup form

### DIFF
--- a/client/src/Signup/Signup.js
+++ b/client/src/Signup/Signup.js
@@ -392,8 +392,8 @@ export function Signup() {
           valuePropName="checked"
           rules={[
             {
-              required: true,
-              message: t('termsRequired')
+              validator: (_, value) =>
+                value ? Promise.resolve() : Promise.reject(t('termsRequired'))
             }
           ]}
           wrapperCol={{ lg: 24 }}
@@ -402,7 +402,6 @@ export function Signup() {
             style={{ textAlign: 'left' }}
             checked={user.serviceAgreementAccepted}
             className="flex"
-            name="serviceAgreementAccepted"
             onChange={() => {
               setUser({
                 ...user,


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

https://github.com/pieforproviders/pieforproviders/issues/249

Passes a custom validator function in the rule object to make sure the service agreement checkbox is checked.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

1. Go to the signup form and fill all the details except the service agreement checkbox
2. Click the **SIGN UP** button. You should find the _Please read and agree to our Terms of Service_ message.
3. Check the checkbox and uncheck it again. You should find the error message again.

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
