### PR TITLE
Fix service agreement acceptance validation in the User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < UuidApplicationRecord
   validates :opt_in_email, inclusion: { in: [true, false] }
   validates :opt_in_text, inclusion: { in: [true, false] }
   validates :phone_number, uniqueness: true, allow_nil: true
-  validates :service_agreement_accepted, inclusion: { in: [true, false] }
+  validates :service_agreement_accepted, presence: true
   validates :timezone, presence: true
 
   scope :active, -> { where(active: true) }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     password_confirmation { password }
     phone_number { Faker::PhoneNumber.phone_number }
     phone_type { %w[cell home work].sample }
-    service_agreement_accepted { Faker::Boolean.boolean }
+    service_agreement_accepted { true }
     timezone { TimeZoneService.us_zones.sample }
 
     factory :confirmed_user do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe User, type: :model do
   it { should validate_presence_of(:organization) }
   it { should validate_uniqueness_of(:phone_number).ignoring_case_sensitivity }
   it { should validate_presence_of(:timezone) }
+  it { should validate_presence_of(:service_agreement_accepted) }
 
   let!(:user) { create(:confirmed_user, phone_number: '888-888-8888') }
   it 'formats a phone number with non-digit characters' do

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe 'POST /signup', type: :request do
       password_confirmation: 'password',
       phone_number: '888-888-8888',
       phone_type: 'cell',
-      timezone: 'Eastern Time (US & Canada)'
+      timezone: 'Eastern Time (US & Canada)',
+      service_agreement_accepted: true
     }
   end
 


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

Previously, a user was able to sign up without accepting the service agreement. This PR fixes the validation of the `service_agreement_accepted` field in the API to make sure it is `true`.

The frontend validation is handled in #261.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write tests?
* [x] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [x] Did you run `bundle exec rubocop` from the root?
* [ ] Did you run `yarn lint` in `/client`?
* [ ] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
