### PR TITLE
Add not null constraint to users' greeting name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < UuidApplicationRecord
   validates :active, inclusion: { in: [true, false] }
   validates :email, presence: true, uniqueness: true
   validates :full_name, presence: true
+  validates :greeting_name, presence: true
   validates :language, presence: true
   validates :organization, presence: true
   validates :opt_in_email, inclusion: { in: [true, false] }
@@ -47,7 +48,7 @@ end
 #  encrypted_password         :string           default(""), not null
 #  failed_attempts            :integer          default(0), not null
 #  full_name                  :string           not null
-#  greeting_name              :string
+#  greeting_name              :string           not null
 #  language                   :string           not null
 #  last_sign_in_at            :datetime
 #  last_sign_in_ip            :inet

--- a/db/migrate/20200902182940_add_not_null_constraint_to_users_greeting_name.rb
+++ b/db/migrate/20200902182940_add_not_null_constraint_to_users_greeting_name.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintToUsersGreetingName < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :users, :greeting_name, false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,20 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
---
 -- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -296,7 +282,7 @@ CREATE TABLE public.users (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     active boolean DEFAULT true NOT NULL,
     full_name character varying NOT NULL,
-    greeting_name character varying,
+    greeting_name character varying NOT NULL,
     email character varying NOT NULL,
     language character varying NOT NULL,
     phone_type character varying,
@@ -711,6 +697,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200825180100'),
 ('20200825180200'),
 ('20200825180300'),
-('20200828013851');
+('20200828013851'),
+('20200902182940');
 
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -38,7 +38,7 @@ end
 #  encrypted_password         :string           default(""), not null
 #  failed_attempts            :integer          default(0), not null
 #  full_name                  :string           not null
-#  greeting_name              :string
+#  greeting_name              :string           not null
 #  language                   :string           not null
 #  last_sign_in_at            :datetime
 #  last_sign_in_ip            :inet

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe User, type: :model do
   it { should validate_presence_of(:email) }
   it { should validate_uniqueness_of(:email).ignoring_case_sensitivity }
   it { should validate_presence_of(:full_name) }
+  it { should validate_presence_of(:greeting_name) }
   it { should validate_presence_of(:language) }
   it { should validate_presence_of(:organization) }
   it { should validate_uniqueness_of(:phone_number).ignoring_case_sensitivity }
@@ -32,7 +33,7 @@ end
 #  encrypted_password         :string           default(""), not null
 #  failed_attempts            :integer          default(0), not null
 #  full_name                  :string           not null
-#  greeting_name              :string
+#  greeting_name              :string           not null
 #  language                   :string           not null
 #  last_sign_in_at            :datetime
 #  last_sign_in_ip            :inet


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

The greeting name has a presence validation in the frontend but the table lacks it. This PR adds a not-null constraint to `users.greeting_name` and adds a model validation.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write tests?
* [x] Did you run `bundle exec rspec` from the root?
* [x] Did you run `bundle exec rails rswag` from the root?
* [x] Did you run `bundle exec rubocop` from the root?
* [ ] Did you run `yarn lint` in `/client`?
* [ ] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [x] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

Run `rails db:migrate`

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
