### PR TITLE
Add Accept-Language header to all API requests

### DIFF
--- a/client/src/Login/Login.js
+++ b/client/src/Login/Login.js
@@ -13,7 +13,7 @@ export function Login() {
 
   const { makeRequest } = useApiResponse()
   let history = useHistory()
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
 
   const ResendToken = ({ type }) => {
     return (
@@ -48,8 +48,7 @@ export function Login() {
     const response = await makeRequest({
       type: 'post',
       url: '/login',
-      data: { user: values },
-      headers: { 'Accept-Language': i18n.language }
+      data: { user: values }
     })
     if (!response.ok || response.headers.get('authorization') === null) {
       const errorMessage = await response.json()

--- a/client/src/Signup/Signup.js
+++ b/client/src/Signup/Signup.js
@@ -47,8 +47,7 @@ export function Signup() {
     const response = await makeRequest({
       type: 'post',
       url: '/signup',
-      data: { user: user },
-      headers: { 'Accept-Language': i18n.language }
+      data: { user: user }
     })
     if (response.status === 201) {
       setSuccess(true)

--- a/client/src/_shared/_hooks/useApiResponse.js
+++ b/client/src/_shared/_hooks/useApiResponse.js
@@ -1,3 +1,4 @@
+import i18n from 'i18n'
 import useApi from '_shared/_hooks/useApi'
 import apiErrorHandler from '_utils/apiErrorHandler'
 import useUnauthorizedHandler from '_shared/_hooks/useUnauthorizedHandler'
@@ -14,7 +15,8 @@ export const useApiResponse = () => {
     const headers = {
       ...requestHeaders,
       Accept: 'application/vnd.pieforproviders.v1+json',
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'Accept-Language': i18n.language
     }
 
     const result = (async () => {


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

https://github.com/pieforproviders/pieforproviders/issues/277

We weren't sending the `Accept-Language` header to `GET /confirmation`. This PR adds the header to be sent for all requests.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

 1.  Sign up in English
 1.  Before using the confirmation URL with a bad token, go to the login page and switch the language to Spanish
 1.  Use the URL with a bad confirmation token
 1.  The alert should be displayed in Spanish

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->

Note that if you switch the language after seeing the error notification, the notification title will not be translated as it comes from the server.
