### PR TITLE
Display user's greeting name on the Getting Started page

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,7 +2,7 @@
 
 # API for application users
 class Api::V1::UsersController < Api::V1::ApiController
-  before_action :set_user, only: %i[show update destroy]
+  before_action :set_user, only: %i[update destroy]
   skip_before_action :authenticate_user!, only: %i[create]
 
   # GET /users
@@ -12,9 +12,9 @@ class Api::V1::UsersController < Api::V1::ApiController
     render json: @users
   end
 
-  # GET /users/:slug
+  # GET /profile
   def show
-    render json: @user
+    render json: current_user
   end
 
   # POST /users

--- a/client/src/GettingStarted/GettingStarted.js
+++ b/client/src/GettingStarted/GettingStarted.js
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Card, Typography } from 'antd'
+import { useApiResponse } from '_shared/_hooks/useApiResponse'
 import Icon from '@material-ui/core/Icon'
 import AssignmentIcon from '@material-ui/icons/Assignment'
 import BusinessIcon from '@material-ui/icons/Business'
@@ -8,13 +9,31 @@ import PlaylistAddIcon from '@material-ui/icons/PlaylistAdd'
 import { useTranslation } from 'react-i18next'
 import { PaddedButton } from '_shared/PaddedButton'
 
-const userGreetingName = 'Amanda'
 // NB: we're using CSS grid instead of Ant grid for these cards
 // because Ant grid doesn't flow into the next row when there are
 // more cards than columns
 
 export function GettingStarted() {
+  const [user, setUser] = useState(null)
   const { t } = useTranslation()
+  const { makeRequest } = useApiResponse()
+
+  useEffect(() => {
+    const getUser = async () => {
+      const response = await makeRequest({
+        type: 'get',
+        url: '/api/v1/profile',
+        headers: {
+          Authorization: localStorage.getItem('pie-token')
+        }
+      })
+      const user = await response.json()
+      setUser(user)
+    }
+
+    getUser()
+  }, [])
+
   const cards = [
     {
       description: t('gettingStartedBusinesses'),
@@ -42,7 +61,7 @@ export function GettingStarted() {
       <div className="getting-started-content-area">
         <Typography.Title className="text-center">
           {t('gettingStartedWelcome')}
-          {userGreetingName}!
+          {user && `, ${user.greeting_name}!`}
         </Typography.Title>
 
         <div className="mb-8">

--- a/client/src/GettingStarted/__tests__/GettingStarted.test.js
+++ b/client/src/GettingStarted/__tests__/GettingStarted.test.js
@@ -1,10 +1,18 @@
 import React from 'react'
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { GettingStarted } from '../GettingStarted'
-import { renderWithi18next } from 'setupTests'
 
+const doRender = () => {
+  return render(
+    <MemoryRouter>
+      <GettingStarted />
+    </MemoryRouter>
+  )
+}
 describe('<GettingStarted />', () => {
   it('renders the GettingStarted container', () => {
-    const { container } = renderWithi18next(<GettingStarted />)
+    const { container } = doRender()
     expect(container).toHaveTextContent('Welcome to Pie for Providers')
   })
 })

--- a/client/src/i18n/locales/en/index.json
+++ b/client/src/i18n/locales/en/index.json
@@ -69,7 +69,7 @@
   "gettingStartedDetailsTitle": "Add your business info",
   "gettingStartedAgencies": "Let us know which agencies provide subsidies for which children, so we can keep track of your monthly billing cycles.",
   "gettingStartedAgenciesTitle": "Assign children to agencies",
-  "gettingStartedWelcome": "Welcome to Pie for Providers, ",
+  "gettingStartedWelcome": "Welcome to Pie for Providers",
   "gettingStartedTitle": "Let's Get Started",
   "gettingStartedInstructions": "Follow these instructions to set up your case dashboard. This should take about 15 minutes, and you'll only have to do this once. Get ready to increase your slice of the pie!",
   "gettingStartedButton": "Get Started",

--- a/client/src/i18n/locales/es/index.json
+++ b/client/src/i18n/locales/es/index.json
@@ -69,7 +69,7 @@
   "gettingStartedDetailsTitle": "Agrega la información de tu empresa",
   "gettingStartedAgencies": "Avísanos cuales agencias proporcionan subsidios para cuales niños, para que podamos mantener un registro de tus ciclos de facturación mensuales",
   "gettingStartedAgenciesTitle": "Asigna niños a agencias",
-  "gettingStartedWelcome": "Bienvenidas a Pie for Providers, ",
+  "gettingStartedWelcome": "Bienvenidas a Pie for Providers",
   "gettingStartedTitle": "Comencemos",
   "gettingStartedInstructions": "Sigue estas instrucciones para configurar tu pantalla principal de casos. Esto debería tardar unos 15 minutos y solo tendrás que hacerlo una vez. ¡Prepárate para aumentar tu porción del pastel!",
   "gettingStartedButton": "Comienza",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,8 @@ Rails.application.routes.draw do
 
   scope module: :api, defaults: { format: :json }, path: 'api' do
     scope module: :v1, constraints: ApiConstraint.new(version: 1, default: true), path: 'v1' do
-      resources :users, param: :slug
+      resources :users, param: :slug, except: [:show]
+      get 'profile', to: 'users#show'
       resources :businesses, param: :slug
       resources :sites, param: :slug
       resources :children, param: :slug

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -61,8 +61,32 @@ RSpec.describe 'users API', type: :request do
     end
   end
 
-  it_behaves_like 'it retrieves an item with a slug, for a user', User do
-    let(:item_params) { user_params }
+  describe 'user profile' do
+    path '/api/v1/profile' do
+      let(:item_params) { user_params }
+
+      get 'retrieves the user profile' do
+        tags 'users'
+
+        produces 'application/json', 'application/xml'
+
+        context 'on the right api version' do
+          include_context 'correct api version header'
+          context 'when authenticated' do
+            include_context 'authenticated user'
+            response '200', 'profile found' do
+              run_test! do
+                expect(response).to match_response_schema('user')
+              end
+            end
+          end
+
+          it_behaves_like '401 error if not authenticated with parameters', 'user'
+        end
+
+        it_behaves_like 'server error responses for wrong api version with parameters', 'user'
+      end
+    end
   end
 
   it_behaves_like 'it updates an item with a slug', User, 'full_name', 'Ron Weasley', nil do

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -824,30 +824,15 @@
         }
       }
     },
-    "/api/v1/users/{slug}": {
-      "parameters": [
-        {
-          "name": "slug",
-          "in": "path",
-          "required": true,
-          "schema": {
-            "type": "string"
-          }
-        }
-      ],
+    "/api/v1/profile": {
       "get": {
-        "summary": "retrieves a user",
+        "summary": "retrieves the user profile",
         "tags": [
           "users"
         ],
         "responses": {
           "200": {
-            "description": "user found",
-            "content": {
-            }
-          },
-          "404": {
-            "description": "user not found",
+            "description": "profile found",
             "content": {
             }
           },
@@ -862,7 +847,19 @@
             }
           }
         }
-      },
+      }
+    },
+    "/api/v1/users/{slug}": {
+      "parameters": [
+        {
+          "name": "slug",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
       "put": {
         "summary": "updates a user",
         "tags": [


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->
https://github.com/pieforproviders/pieforproviders/issues/281

- Replaces `/users/:slug` with /`profile` in the API and adds tests
- Displays the user's greeting name on the Getting Started page
- Updates frontend unit tests

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write tests?
* [x] Did you run `bundle exec rspec` from the root?
* [x] Did you run `bundle exec rails rswag` from the root?
* [x] Did you run `bundle exec rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

1. Sign up and log in to the account
2. Go to `/getting-started`
3. You should find the greeting name next to 'Welcome to Pie for Providers'

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
