### PR TITLE
Adds dependabot config to ignore eslint

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,14 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    ignored_updates:
+      - match:
+          dependency_name: "eslint"
+  - package_manager: "javascript"
+    directory: "client/"
+    update_schedule: "weekly"
+    ignored_updates:
+      - match:
+          dependency_name: "eslint"


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
See #299 comment - we don't want to upgrade eslint because react-scripts uses an older version and it's pinned at that version for create-react-app-generated apps