### PR TITLE
Sets up breakpoints

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -15,7 +15,6 @@ import Signup from './Signup'
 import NotFound from './NotFound'
 import ErrorBoundary from './ErrorBoundary'
 import CasesImport from './CasesImport'
-import { Layout } from 'antd'
 import { AuthLayout } from '_shared'
 import { isUserLoggedIn } from '_utils'
 import { useTranslation } from 'react-i18next'
@@ -32,55 +31,44 @@ const App = () => {
   }, [])
 
   return (
-    <Layout
-      breakpoint={{
-        xs: '0px',
-        sm: '360px',
-        md: '768px',
-        lg: '1024px',
-        xl: '1280px'
-      }}
-      className="bg-white"
-    >
-      <div className="text-primaryBlue font-proxima text-sm h-screen">
-        <ErrorBoundary>
-          <Router>
-            <Switch>
-              <Route path="/signup">
-                <AuthLayout
-                  backgroundImageClass="auth-image"
-                  contentComponent={Signup}
-                />
-              </Route>
-              <Route path="/login">
-                <AuthLayout
-                  backgroundImageClass="auth-image"
-                  contentComponent={Login}
-                />
-              </Route>
-              <Route
-                path="/confirm"
-                title="Confirm your Account"
-                component={Confirmation}
+    <div className="text-primaryBlue font-proxima text-sm h-screen">
+      <ErrorBoundary>
+        <Router>
+          <Switch>
+            <Route path="/signup">
+              <AuthLayout
+                backgroundImageClass="auth-image"
+                contentComponent={Signup}
               />
-              <AuthorizedRoute exact path="/getting-started" title={t('setup')}>
-                <GettingStarted />
-              </AuthorizedRoute>
-              <AuthorizedRoute exact path="/dashboard">
-                <Dashboard />
-              </AuthorizedRoute>
-              <AuthorizedRoute exact path="/cases/import">
-                <CasesImport />
-              </AuthorizedRoute>
-              <Route exact path="/">
-                <Redirect to={isUserLoggedIn ? '/dashboard' : '/login'} />
-              </Route>
-              <Route component={NotFound} />
-            </Switch>
-          </Router>
-        </ErrorBoundary>
-      </div>
-    </Layout>
+            </Route>
+            <Route path="/login">
+              <AuthLayout
+                backgroundImageClass="auth-image"
+                contentComponent={Login}
+              />
+            </Route>
+            <Route
+              path="/confirm"
+              title="Confirm your Account"
+              component={Confirmation}
+            />
+            <AuthorizedRoute exact path="/getting-started" title={t('setup')}>
+              <GettingStarted />
+            </AuthorizedRoute>
+            <AuthorizedRoute exact path="/dashboard">
+              <Dashboard />
+            </AuthorizedRoute>
+            <AuthorizedRoute exact path="/cases/import">
+              <CasesImport />
+            </AuthorizedRoute>
+            <Route exact path="/">
+              <Redirect to={isUserLoggedIn ? '/dashboard' : '/login'} />
+            </Route>
+            <Route component={NotFound} />
+          </Switch>
+        </Router>
+      </ErrorBoundary>
+    </div>
   )
 }
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -15,6 +15,7 @@ import Signup from './Signup'
 import NotFound from './NotFound'
 import ErrorBoundary from './ErrorBoundary'
 import CasesImport from './CasesImport'
+import { Layout } from 'antd'
 import { AuthLayout } from '_shared'
 import { isUserLoggedIn } from '_utils'
 import { useTranslation } from 'react-i18next'
@@ -31,44 +32,55 @@ const App = () => {
   }, [])
 
   return (
-    <div className="text-primaryBlue font-proxima text-sm h-screen">
-      <ErrorBoundary>
-        <Router>
-          <Switch>
-            <Route path="/signup">
-              <AuthLayout
-                backgroundImageClass="auth-image"
-                contentComponent={Signup}
+    <Layout
+      breakpoint={{
+        xs: '0px',
+        sm: '360px',
+        md: '768px',
+        lg: '1024px',
+        xl: '1280px'
+      }}
+      className="bg-white"
+    >
+      <div className="text-primaryBlue font-proxima text-sm h-screen">
+        <ErrorBoundary>
+          <Router>
+            <Switch>
+              <Route path="/signup">
+                <AuthLayout
+                  backgroundImageClass="auth-image"
+                  contentComponent={Signup}
+                />
+              </Route>
+              <Route path="/login">
+                <AuthLayout
+                  backgroundImageClass="auth-image"
+                  contentComponent={Login}
+                />
+              </Route>
+              <Route
+                path="/confirm"
+                title="Confirm your Account"
+                component={Confirmation}
               />
-            </Route>
-            <Route path="/login">
-              <AuthLayout
-                backgroundImageClass="auth-image"
-                contentComponent={Login}
-              />
-            </Route>
-            <Route
-              path="/confirm"
-              title="Confirm your Account"
-              component={Confirmation}
-            />
-            <AuthorizedRoute exact path="/getting-started" title={t('setup')}>
-              <GettingStarted />
-            </AuthorizedRoute>
-            <AuthorizedRoute exact path="/dashboard">
-              <Dashboard />
-            </AuthorizedRoute>
-            <AuthorizedRoute exact path="/cases/import">
-              <CasesImport />
-            </AuthorizedRoute>
-            <Route exact path="/">
-              <Redirect to={isUserLoggedIn ? '/dashboard' : '/login'} />
-            </Route>
-            <Route component={NotFound} />
-          </Switch>
-        </Router>
-      </ErrorBoundary>
-    </div>
+              <AuthorizedRoute exact path="/getting-started" title={t('setup')}>
+                <GettingStarted />
+              </AuthorizedRoute>
+              <AuthorizedRoute exact path="/dashboard">
+                <Dashboard />
+              </AuthorizedRoute>
+              <AuthorizedRoute exact path="/cases/import">
+                <CasesImport />
+              </AuthorizedRoute>
+              <Route exact path="/">
+                <Redirect to={isUserLoggedIn ? '/dashboard' : '/login'} />
+              </Route>
+              <Route component={NotFound} />
+            </Switch>
+          </Router>
+        </ErrorBoundary>
+      </div>
+    </Layout>
   )
 }
 

--- a/client/src/App.less
+++ b/client/src/App.less
@@ -1,1 +1,2 @@
 @import '~antd/dist/antd.less';
+@import '_assets/styles/customize-antd.less'

--- a/client/src/App.less
+++ b/client/src/App.less
@@ -1,2 +1,2 @@
 @import '~antd/dist/antd.less';
-@import '_assets/styles/customize-antd.less'
+@import '_assets/styles/customize-antd.less';

--- a/client/src/GettingStarted/GettingStarted.js
+++ b/client/src/GettingStarted/GettingStarted.js
@@ -74,7 +74,7 @@ export function GettingStarted() {
         </div>
 
         <Typography.Title level={3}>{t('steps')}</Typography.Title>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mx-4">
+        <div className="grid grid-cols-1 xs:grid-cols-2 md:grid-cols-4 gap-4 mx-4">
           {cards.map((card, idx) => (
             <Card
               bordered={false}

--- a/client/src/Login/Login.js
+++ b/client/src/Login/Login.js
@@ -126,7 +126,7 @@ export function Login() {
         layout="vertical"
         name="login"
         onFinish={onFinish}
-        wrapperCol={{ lg: 12 }}
+        wrapperCol={{ md: 12 }}
       >
         <Form.Item
           className="text-primaryBlue"

--- a/client/src/Signup/Signup.js
+++ b/client/src/Signup/Signup.js
@@ -114,7 +114,7 @@ export function Signup() {
         layout="vertical"
         onFinish={onFinish}
         name="signup"
-        wrapperCol={{ lg: 12 }}
+        wrapperCol={{ md: 12 }}
       >
         <Form.Item
           label={t('organization')}
@@ -395,7 +395,7 @@ export function Signup() {
                 value ? Promise.resolve() : Promise.reject(t('termsRequired'))
             }
           ]}
-          wrapperCol={{ lg: 24 }}
+          wrapperCol={{ md: 24 }}
         >
           <Checkbox
             style={{ textAlign: 'left' }}
@@ -411,7 +411,7 @@ export function Signup() {
             <TermsLabel />
           </Checkbox>
         </Form.Item>
-        <Form.Item wrapperCol={{ lg: 8 }} className="text-center">
+        <Form.Item wrapperCol={{ md: 8 }} className="text-center">
           <PaddedButton text={t('signup')} />
         </Form.Item>
       </Form>

--- a/client/src/_assets/styles/customize-antd.less
+++ b/client/src/_assets/styles/customize-antd.less
@@ -1,0 +1,20 @@
+// Media queries breakpoints
+// Extra small screen / phone
+@screen-xs              : 360px;
+@screen-xs-min          : @screen-xs;
+@screen-xs-max          : (@screen-xs-min - 1);
+
+// Small screen / tablet
+@screen-sm              : 768px;
+@screen-sm-min          : @screen-sm;
+@screen-sm-max          : (@screen-sm-min - 1);
+
+// Medium screen / desktop
+@screen-md              : 1024px;
+@screen-md-min          : @screen-md;
+@screen-md-max          : (@screen-md-min - 1);
+
+// Large screen / wide desktop
+@screen-lg              : 1280px;
+@screen-lg-min          : @screen-lg;
+@screen-lg-max          : (@screen-lg-min - 1);

--- a/client/src/_shared/AuthLayout.js
+++ b/client/src/_shared/AuthLayout.js
@@ -15,19 +15,19 @@ export function AuthLayout({
   return (
     <Row className="h-screen">
       <Col
-        lg={12}
+        md={12}
         className={`h-screen bg-no-repeat bg-cover ${backgroundImageClass}`}
       />
       <Col
         xs={24}
-        lg={12}
-        className="overflow-y-scroll mt-4 sm:mt-8 px-4 lg:px-8"
+        md={12}
+        className="overflow-y-scroll mt-4 xs:mt-8 px-4 md:px-8"
       >
-        <Row gutter={{ xs: 16, lg: 32 }}>
+        <Row gutter={{ xs: 16, md: 32 }}>
           <Col
             xs={24}
             sm={{ span: 12, offset: 6 }}
-            lg={{ span: 24, offset: 0 }}
+            md={{ span: 24, offset: 0 }}
           >
             <div className="text-right">
               <ActionLink
@@ -38,11 +38,11 @@ export function AuthLayout({
                 classes="text-right no-underline p-0 h-auto"
               />
             </div>
-            <div className="text-center lg:text-left">
+            <div className="text-center md:text-left">
               <img
                 alt={t('pieforProvidersLogoAltText')}
                 src={pieFullTanLogo}
-                className="w-24 sm:w-48 mt-0 mb-10 sm:mb-16 lg:mb-12 mx-auto"
+                className="w-24 xs:w-48 mt-0 mb-10 xs:mb-16 md:mb-12 mx-auto"
               />
               <ContentComponent />
             </div>

--- a/client/src/_shared/LoggedInLayout.js
+++ b/client/src/_shared/LoggedInLayout.js
@@ -37,7 +37,7 @@ export function LoggedInLayout({ children, title }) {
           {t('logout')}
         </Button>
       </div>
-      <div className="w-full sm:h-full px-4 mt-4">
+      <div className="w-full xs:h-full px-4 mt-4">
         {title && (
           <Breadcrumb className="mb-2">
             <Breadcrumb.Item>{title}</Breadcrumb.Item>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -29,6 +29,13 @@ module.exports = {
       }
     }
   },
+  screens: {
+    xs: '0px',
+    sm: '360px',
+    md: '768px',
+    lg: '1024px',
+    xl: '1280px'
+  },
   plugins: [require('./tailwind/plugins/base')()],
   future: {
     removeDeprecatedGapUtilities: true

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -30,11 +30,10 @@ module.exports = {
     }
   },
   screens: {
-    xs: '0px',
-    sm: '360px',
-    md: '768px',
-    lg: '1024px',
-    xl: '1280px'
+    xs: '360px',
+    sm: '768px',
+    md: '1024px',
+    lg: '1280px'
   },
   plugins: [require('./tailwind/plugins/base')()],
   future: {


### PR DESCRIPTION
# 💅🏼 What issue does this fix?

#238 sets breakpoints at our custom screen sizes for both tailwind and Ant Design

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [X] Did you run `bundle exec rspec` from the root?
* [X] Did you run `bundle exec rails rswag` from the root?
* [X] Did you run `bundle exec rubocop` from the root?
* [X] Did you run `yarn lint` in `/client`?
* [X] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧳 Steps to test

Change your screen to our breakpoints as laid out in the ticket, you should see the expected screens from Figma.  Our sizes will be:

```
    xs: '360px',
    sm: '768px',
    md: '1024px',
    lg: '1280px'
```
because of limitations with Ant design