### PR TITLE
Display an error message if the user has already confirmed their email address

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -9,7 +9,8 @@ class ConfirmationsController < Devise::ConfirmationsController
     if successfully_sent?(resource)
       respond_with(resource)
     else
-      respond_with({ error: I18n.t('errors.messages.confirmation_resent') })
+      errors(resource.errors.details)
+      render json: error_response, status: :unprocessable_entity
     end
   end
 

--- a/client/src/Signup/ConfirmationSent.js
+++ b/client/src/Signup/ConfirmationSent.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import { useHistory } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Divider, Typography, Alert } from 'antd'
 import { useApiResponse } from '_shared/_hooks/useApiResponse'
@@ -27,6 +28,7 @@ ListItem.propTypes = {
 
 const ConfirmationSent = ({ userEmail }) => {
   const { t } = useTranslation()
+  const history = useHistory()
   const { makeRequest } = useApiResponse()
   const [resent, setResent] = useState(null)
 
@@ -34,10 +36,26 @@ const ConfirmationSent = ({ userEmail }) => {
     setResent(null)
     const response = await makeRequest({
       type: 'post',
-      url: `confirmation?email=${userEmail}`
+      url: '/confirmation',
+      data: {
+        email: userEmail
+      }
     })
     if (response.ok) {
       setResent(true)
+    } else {
+      const errorMessage = await response.json()
+      history.push({
+        pathname: '/login',
+        state: {
+          error: {
+            status: response.status,
+            message: errorMessage.error,
+            attribute: errorMessage.attribute,
+            type: errorMessage.type
+          }
+        }
+      })
     }
   }
 

--- a/client/src/i18n/locales/en/index.json
+++ b/client/src/i18n/locales/en/index.json
@@ -84,7 +84,7 @@
 
   "genericErrorMessage": "Something went wrong, try again later.",
 
-  "alreadyConfirmed": "This email has already been confirmed, please try logging in. If you've forgotten your password, please reset it below.",
+  "alreadyConfirmed": "You have already verified your account. You can now log in.",
   "emailUnconfirmed": "You have to confirm your email address before continuing.",
   "confirmationPeriodExpired": "Your confirmation period has expired.",
   "genericEmailConfirmationError": "We've run into a problem confirming your email.",

--- a/client/src/i18n/locales/es/index.json
+++ b/client/src/i18n/locales/es/index.json
@@ -84,7 +84,7 @@
 
   "genericErrorMessage": "Algo salió mal, inténtalo de nuevo más tarde.",
 
-  "alreadyConfirmed": "Este correo electrónico ya ha sido confirmado, por favor intenta iniciar sesión. Si has olvidado tu contraseña, por favor resetéala abajo",
+  "alreadyConfirmed": "Ya has verificado tu cuenta. Ahora puedes iniciar sesión.",
   "emailUnconfirmed": "Tienes que confirmar tu correo antes de continuar.",
   "confirmationPeriodExpired": "Tu periodo de confirmación ha expirado",
   "genericEmailConfirmationError": "Hemos tenido un problema en confirmar tu correo.",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,7 +48,6 @@ en:
     messages:
       taken: "has already been taken"
       confirmation: "Confirmation Error"
-      confirmation_resent: "Confirmation could not be resent"
   mailers:
     confirmation_instructions:
       body: Welcome to Pie for Providers! Get ready to increase your slice of the pie with simple child care subsidy management tools. To get started, please verify your email address by clicking the link below (you can also copy and paste it into your browser).

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -17,7 +17,6 @@ es:
     messages:
       taken: "ya ha sido tomado"
       confirmation: "Error de confirmación"
-      confirmation_resent: "No se pudo reenviar la confirmación"
   mailers:
     confirmation_instructions:
       body: ¡Bienvenidas a Pie for Providers! Prepárate para aumentar tu porción del pastel con herramientas sencillas de administración del subsidio. Para empezar, por favor verifica tu dirección de correo haciendo clic en el enlace abajo (también puedes copiar y pegar en su navegador).

--- a/spec/cypress/app_commands/scenarios/confirm_user_account.rb
+++ b/spec/cypress/app_commands/scenarios/confirm_user_account.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+user = User.first
+user&.update! confirmed_at: DateTime.current

--- a/spec/cypress/integration/signup.spec.js
+++ b/spec/cypress/integration/signup.spec.js
@@ -85,18 +85,41 @@ describe('Signup', () => {
       cy.wait('@signup')
       cy.location('pathname').should('eq', '/signup')
     })
+
     it('allows the user to sign up and displays confirmation sent info', () => {
       cy.get(createSelector('signupThanks')).should('exist')
     })
+
     it('allows the user to request new confirmation', () => {
       cy.route({
         method: 'POST',
-        url: `/confirmation?email=${email}`
+        url: '/confirmation'
       }).as('resend')
       cy.get(createSelector('signupThanks')).should('exist')
       cy.get(createSelector('resendConfirmation')).click()
       cy.wait('@resend')
       cy.get(createSelector('resent')).should('exist')
+    })
+
+    it('displays an error message if the user has already confirmed their account', () => {
+      cy.route({
+        method: 'POST',
+        url: '/confirmation'
+      }).as('resend')
+      cy.get(createSelector('signupThanks')).should('exist')
+      cy.get(createSelector('resendConfirmation')).click()
+      cy.wait('@resend')
+
+      cy.appScenario('confirmUserAccount')
+      cy.get(createSelector('resendConfirmation')).click()
+      cy.wait('@resend')
+      cy.location('pathname').should('eq', '/login')
+      cy.get(createSelector('authError')).contains(
+        'You have already verified your account. You can now log in.',
+        {
+          matchCase: false
+        }
+      )
     })
   })
 })


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

https://github.com/pieforproviders/pieforproviders/issues/318

If the user clicks on the **Click here to resend the email** link after confirming their email address, they are redirected to the login page and an error message is shown.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write tests?
* [x] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [x] Did you run `bundle exec rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

1. Sign up for an account. You should be taken to the confirmation instructions page
2. Click on the link in the confirmation email sent to your email address
3. Go back to the confirmation instructions page and click the **Click here to resend the email** link. You should be taken to the login page and the error message _You have already verified your account. You can now log in._ should show up

Note that the alert title **Confirmation Error** will not be translated upon switching the language to Spanish. This is because the message comes from the backend. The fix involves updating the code which displays login errors and will be handled in a separate PR.

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
