### PR TITLE
Fix prep rake task

### DIFF
--- a/lib/tasks/prep.rake
+++ b/lib/tasks/prep.rake
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 task prep: :environment do
-  exec 'yarn lint:fix && yarn test-once && bundle exec rubocop -a && bundle exec rspec && COVERAGE=false bundle exec rails rswag && yarn heroku-postbuild && yarn cy:ci'
+  exec 'yarn lint:fix && yarn test-once && bundle exec rubocop -a && bundle exec rspec && COVERAGE=false bundle exec rails rswag && yarn cy:ci'
 end


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

Removes `yarn heroku-postbuild` from the `prep` rake task since it is included as a part of `yarn cy:ci`.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [ ] Did you run `yarn lint` in `/client`?
* [ ] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
