### PR TITLE
Move signup validation error translations to the frontend

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,14 +16,11 @@ class ApplicationController < ActionController::API
 
   def validation_error(resource)
     render json: {
-      errors: [
-        {
-          status: '422',
-          title: 'Unprocessable Entity',
-          detail: resource.errors,
-          code: '100'
-        }
-      ]
+      status: '422',
+      title: 'Unprocessable Entity',
+      errors: resource.errors.details,
+      detail: resource.errors,
+      code: '100'
     }, status: :unprocessable_entity
   end
 

--- a/client/src/Signup/Signup.js
+++ b/client/src/Signup/Signup.js
@@ -53,7 +53,7 @@ export function Signup() {
       setSuccess(true)
     } else if (response.status === 422) {
       const { errors } = await response.json()
-      setValidationErrors(errors[0].detail)
+      setValidationErrors(errors)
     } else {
       setError(true)
     }
@@ -243,7 +243,7 @@ export function Signup() {
               validateStatus={validationErrors?.phone_number && 'error'}
               help={
                 validationErrors?.phone_number &&
-                `${t('phone')} ${validationErrors.phone_number.join(', ')}`
+                `${t('phone')} ${t(validationErrors.phone_number[0].error)}`
               }
             >
               <MaskedInput
@@ -345,7 +345,7 @@ export function Signup() {
           validateStatus={validationErrors?.email && 'error'}
           help={
             validationErrors?.email &&
-            `${t('email')} ${validationErrors.email.join(', ')}`
+            `${t('email')} ${t(validationErrors.email[0].error)}`
           }
         >
           <Input

--- a/client/src/i18n/locales/en/index.json
+++ b/client/src/i18n/locales/en/index.json
@@ -67,6 +67,8 @@
 
   "reportFeedback": "Report feedback",
 
+  "taken": "has already been taken",
+
   "setup": "Setup",
   "steps": "Steps",
   "gettingStartedBusinesses": "Tell us about the businesses and sites you manage, so we know which subsidy payment rates to apply to your cases.",

--- a/client/src/i18n/locales/es/index.json
+++ b/client/src/i18n/locales/es/index.json
@@ -67,6 +67,8 @@
 
   "reportFeedback": "Da comentarios",
 
+  "taken": "ya ha sido tomado",
+
   "setup": "Configuración",
   "steps": "Pasos",
   "gettingStartedBusinesses": "Cuéntanos sobre las empresas y los sitios que gestionas, para que sepamos cuales tarifas del subsidio aplican a tus casos",

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -39,19 +39,19 @@ RSpec.describe 'POST /signup', type: :request do
         context 'with bad data' do
           let(:user) { { "user": { "title": 'whatever' } } }
           run_test! do
-            expect(JSON.parse(response.body)['errors'].first['detail']['email'].first).to eq("can't be blank")
-            expect(JSON.parse(response.body)['errors'].first['detail']['password'].first).to eq("can't be blank")
-            expect(JSON.parse(response.body)['errors'].first['detail']['full_name'].first).to eq("can't be blank")
-            expect(JSON.parse(response.body)['errors'].first['detail']['language'].first).to eq("can't be blank")
-            expect(JSON.parse(response.body)['errors'].first['detail']['organization'].first).to eq("can't be blank")
-            expect(JSON.parse(response.body)['errors'].first['detail']['timezone'].first).to eq("can't be blank")
+            expect(JSON.parse(response.body)['detail']['email'].first).to eq("can't be blank")
+            expect(JSON.parse(response.body)['detail']['password'].first).to eq("can't be blank")
+            expect(JSON.parse(response.body)['detail']['full_name'].first).to eq("can't be blank")
+            expect(JSON.parse(response.body)['detail']['language'].first).to eq("can't be blank")
+            expect(JSON.parse(response.body)['detail']['organization'].first).to eq("can't be blank")
+            expect(JSON.parse(response.body)['detail']['timezone'].first).to eq("can't be blank")
           end
         end
         context 'with an existing user' do
           before(:each) { create(:confirmed_user, email: params[:email]) }
           let(:user) { { "user": params } }
           run_test! do
-            expect(JSON.parse(response.body)['errors'].first['detail']['email'].first).to eq('has already been taken')
+            expect(JSON.parse(response.body)['detail']['email'].first).to eq('has already been taken')
           end
         end
       end


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two -->

https://github.com/pieforproviders/pieforproviders/issues/333

- Updates the error response to include the [error details](https://guides.rubyonrails.org/active_record_validations.html#validations-overview-errors-details) with the validator names (e.g. blank, taken, etc)

- Defines translations for the validator names.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

1. Sign up with an email address that already exists in the database
2. You should find the message "Email has already been taken"  (if the selected language is English)
3. Switch the language to Spanish and you should find the message "Correo ya ha sido tomado"
4. Sign up with a phone number that already exists and the error message should be translatable

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
