### PR TITLE
Add E2E tests for confirmations with expired tokens

### DIFF
--- a/spec/cypress/app_commands/scenarios/confirmation_token_expired.rb
+++ b/spec/cypress/app_commands/scenarios/confirmation_token_expired.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+user = User.first
+user&.update! confirmation_sent_at: 4.days.ago

--- a/spec/cypress/integration/confirmation.spec.js
+++ b/spec/cypress/integration/confirmation.spec.js
@@ -67,9 +67,30 @@ describe('Confirmation', () => {
           url: '/confirmation'
         }).as('confirmation')
 
-        cy.visit(`/confirm`)
+        cy.visit('/confirm')
         cy.wait('@confirmation')
         cy.get(createSelector('authError')).should('exist')
+        cy.location('pathname').should('eq', '/login')
+      })
+    })
+
+    describe('expired confirmation token', () => {
+      it('displays an error message', () => {
+        cy.appScenario('confirmationTokenExpired')
+        cy.server()
+        cy.route({
+          method: 'GET',
+          url: `/confirmation?confirmation_token=${confirmationToken}`
+        }).as('confirmation')
+
+        cy.visit(`/confirm?confirmation_token=${confirmationToken}`)
+        cy.wait('@confirmation')
+        cy.get(createSelector('authError')).contains(
+          'Your confirmation period has expired.',
+          {
+            matchCase: false
+          }
+        )
         cy.location('pathname').should('eq', '/login')
       })
     })


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  DO NOT use "Fixes #123" or anything that will auto-close the ticket, we want the ticket open until it's QAed. -->

https://github.com/pieforproviders/pieforproviders/issues/274

Adds an E2E test to assert an error message is displayed when a user tries to confirm their account with an expired token.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write tests?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment Considerations
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
