### PR TITLE
[426] Accessibility for sign up view

### DIFF
--- a/client/craco.config.js
+++ b/client/craco.config.js
@@ -16,8 +16,8 @@ module.exports = {
               '@select-item-selected-color': '#3B3B3B',
               '@label-color': '@primary-color',
               '@input-placeholder-color': '#676767',
-              '@error-color': '#D64B3A',
-              '@highlight-color': '#D64B3A',
+              '@error-color': '#D23C2A',
+              '@highlight-color': '#D23C2A',
               '@primary-4': '#F3F8FA',
 
               // Typography

--- a/client/src/Login/Login.js
+++ b/client/src/Login/Login.js
@@ -70,13 +70,16 @@ export function Login() {
     history.push('/dashboard')
   }
   return (
-    <>
-      <p className="mb-4">
+    <main>
+      <div className="mb-4">
         <Link to="/signup" className="uppercase">
           {t('signup')}
         </Link>{' '}
-        {t('or')} <span className="uppercase font-bold">{t('login')}</span>
-      </p>
+        {t('or ')} 
+        <h1 className="uppercase font-bold inline-block">
+          {t('login')}
+        </h1>
+      </div>
 
       {apiError && (
         <Alert
@@ -185,6 +188,6 @@ export function Login() {
           />
         </Modal>
       )}
-    </>
+    </main>
   )
 }

--- a/client/src/Login/Login.js
+++ b/client/src/Login/Login.js
@@ -75,10 +75,8 @@ export function Login() {
         <Link to="/signup" className="uppercase">
           {t('signup')}
         </Link>{' '}
-        {t('or ')} 
-        <h1 className="uppercase font-bold inline-block">
-          {t('login')}
-        </h1>
+        {t('or ')}
+        <h1 className="uppercase font-bold inline-block">{t('login')}</h1>
       </div>
 
       {apiError && (

--- a/client/src/PasswordReset/NewPassword.js
+++ b/client/src/PasswordReset/NewPassword.js
@@ -94,9 +94,11 @@ export const NewPassword = () => {
 
   return (
     <>
-      <p className="mb-8">
-        <span className="uppercase font-bold">{t('resetPassword')}</span>
-      </p>
+      <div className="mb-8">
+        <h1 className="uppercase font-bold inline-block">
+          {t('resetPassword')}
+        </h1>
+      </div>
 
       <Form
         layout="vertical"

--- a/client/src/Signup/Signup.js
+++ b/client/src/Signup/Signup.js
@@ -97,9 +97,7 @@ export function Signup() {
   return (
     <main>
       <div className="mb-8">
-        <h1 className="uppercase font-bold inline-block">
-          {t('signup')}
-        </h1>
+        <h1 className="uppercase font-bold inline-block">{t('signup')}</h1>
         {` ${t('or')} `}
         <Link to="/login" className="uppercase">
           {t('login')}
@@ -213,7 +211,7 @@ export function Signup() {
 
         <Form.Item name="phone" label={`${t('phone')} (${t('phoneNote')})`}>
           <Input.Group compact>
-            <label for="rc_select_1" className="sr-only">
+            <label htmlFor="rc_select_1" className="sr-only">
               {t('phoneType')}
             </label>
             <Select
@@ -237,7 +235,7 @@ export function Signup() {
               </Option>
             </Select>
 
-            <label for="signup_phoneNumber" className="sr-only">
+            <label htmlFor="signup_phoneNumber" className="sr-only">
               {t('phone')}
             </label>
             <Form.Item

--- a/client/src/Signup/Signup.js
+++ b/client/src/Signup/Signup.js
@@ -95,14 +95,16 @@ export function Signup() {
   }
 
   return (
-    <>
-      <p className="mb-8">
-        <span className="uppercase font-bold">{t('signup')}</span>
+    <main>
+      <div className="mb-8">
+        <h1 className="uppercase font-bold inline-block">
+          {t('signup')}
+        </h1>
         {` ${t('or')} `}
         <Link to="/login" className="uppercase">
           {t('login')}
         </Link>
-      </p>
+      </div>
 
       {error && (
         <Alert
@@ -211,6 +213,9 @@ export function Signup() {
 
         <Form.Item name="phone" label={`${t('phone')} (${t('phoneNote')})`}>
           <Input.Group compact>
+            <label for="rc_select_1" className="sr-only">
+              {t('phoneType')}
+            </label>
             <Select
               value={user.phoneType}
               style={{ width: '30%', borderRight: '0', textAlign: 'left' }}
@@ -232,6 +237,9 @@ export function Signup() {
               </Option>
             </Select>
 
+            <label for="signup_phoneNumber" className="sr-only">
+              {t('phone')}
+            </label>
             <Form.Item
               name="phoneNumber"
               style={{ width: '70%', marginBottom: 0 }}
@@ -441,6 +449,6 @@ export function Signup() {
           <PaddedButton data-cy="signupBtn" text={t('signup')} />
         </Form.Item>
       </Form>
-    </>
+    </main>
   )
 }

--- a/client/src/_shared/ActionLink.js
+++ b/client/src/_shared/ActionLink.js
@@ -11,7 +11,7 @@ export function ActionLink({ onClick, text = '', classes = '', children }) {
     <>
       <Button
         onClick={handleClick}
-        className={`${classes} focus:shadow-none`}
+        className={`${classes} mt-1`}
         type="link"
       >
         {text || children}

--- a/client/src/_shared/ActionLink.js
+++ b/client/src/_shared/ActionLink.js
@@ -9,11 +9,7 @@ export function ActionLink({ onClick, text = '', classes = '', children }) {
   }
   return (
     <>
-      <Button
-        onClick={handleClick}
-        className={`${classes} mt-1`}
-        type="link"
-      >
+      <Button onClick={handleClick} className={`${classes} mt-1`} type="link">
         {text || children}
       </Button>
     </>

--- a/client/src/_shared/AuthLayout.js
+++ b/client/src/_shared/AuthLayout.js
@@ -29,7 +29,7 @@ export function AuthLayout({
             sm={{ span: 12, offset: 6 }}
             md={{ span: 24, offset: 0 }}
           >
-            <div className="text-right">
+            <header className="text-right">
               <ActionLink
                 onClick={() =>
                   i18n.changeLanguage(i18n.language === 'en' ? 'es' : 'en')
@@ -37,13 +37,13 @@ export function AuthLayout({
                 text={i18n.language === 'en' ? 'Español' : 'English'}
                 classes="text-right no-underline p-0 h-auto"
               />
-            </div>
-            <div className="text-center md:text-left">
               <img
                 alt={t('pieforProvidersLogoAltText')}
                 src={pieFullTanLogo}
                 className="w-24 xs:w-48 mt-0 mb-10 xs:mb-16 md:mb-12 mx-auto"
               />
+            </header>
+            <div className="text-center md:text-left">
               <ContentComponent />
             </div>
           </Col>

--- a/client/src/i18n/locales/en/index.json
+++ b/client/src/i18n/locales/en/index.json
@@ -35,6 +35,7 @@
   "multiBusinessTrue": "Yes, managing multiple child care businesses",
   "phone": "Phone number",
   "phoneNote": "we will only call or text if you want us to",
+  "phoneType": "Phone Type",
   "phoneTypePlaceholder": "Choose one",
   "phoneTypeCell": "Cell",
   "phoneTypeHome": "Home",

--- a/client/src/i18n/locales/es/index.json
+++ b/client/src/i18n/locales/es/index.json
@@ -35,6 +35,7 @@
   "multiBusinessTrue": "Sí, gestiono varios negocios de cuidado infantil",
   "phone": "Número de teléfono",
   "phoneNote": "solo llamaremos o enviaremos un mensaje de texto si lo deseas",
+  "phoneType": "Tipo de telefono",
   "phoneTypePlaceholder": "Elija uno",
   "phoneTypeCell": "Celular",
   "phoneTypeHome": "Casa",

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -16,11 +16,11 @@ module.exports = {
         mediumGray: '#F2F2F2',
         lightGray: '#979797',
         white: '#FFFFFF',
-        red1: '#D64B3A',
+        red1: '#D23C2A',
         red2: '#F9E4E1',
         orange1: '#F8921F',
         orange2: '#FAE7D1',
-        green1: '#179D57',
+        green1: '#00853D',
         green2: '#DCFAEA',
         blueOverlay: '#004A6E80'
       },


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
#426 
Fixes a few accessibility issues:
• Missing two input labels
• Landmark / markup structure issues
• Error text color lacks sufficient contrast
• Language toggle missing focus state

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [x] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🏺 Accessibility
Ran tests and did some manual testing.

## 🛷 Deployment
NA

## 🧵 Steps to set up locally
NA

## 🧳 Steps to test
Go to the sign up view and run [axe](https://www.deque.com/axe/) or [Lighthouse](https://developers.google.com/web/tools/lighthouse)

## 🕯 Caveats, concerns
There will be some ARIA issues flagged by the tests, but I imagine it would be very hard to untangle from the Ant components (I'm not qualified). There are also three color contrast issues that are flagged - two are false and one is for a non-essential element that would require some css overrides of the Ant styles, so I left it for now.
