### PR TITLE
check window width for navbar and hold in state to re-render as needed

### DIFF
--- a/client/src/_shared/LoggedInLayout.js
+++ b/client/src/_shared/LoggedInLayout.js
@@ -70,6 +70,8 @@ export function LoggedInLayout({ children, title }) {
     )
   }
 
+  // listening for width changes of the window to make the site responsive
+  // unfortunately, ant-design breakpoints didn't include 768 <=, but 768 >=
   useEffect(() => {
     window.addEventListener('resize', setWidth)
 

--- a/client/src/_shared/LoggedInLayout.js
+++ b/client/src/_shared/LoggedInLayout.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { useHistory } from 'react-router-dom'
 import pieSliceLogo from '_assets/pieSliceLogo.svg'
@@ -14,6 +14,8 @@ const { useBreakpoint } = Grid
 export function LoggedInLayout({ children, title }) {
   const dispatch = useDispatch()
   const { t, i18n } = useTranslation()
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+  const setWidth = () => setWindowWidth(window.innerWidth)
   const history = useHistory()
   const screens = useBreakpoint()
 
@@ -24,28 +26,55 @@ export function LoggedInLayout({ children, title }) {
 
   const changeLanguage = lang => i18n.changeLanguage(lang)
 
-  const mobileMenu = (
-    <Menu>
+  const renderDesktopMenu = () => (
+    <>
       {i18n.language === 'es' ? (
-        <Menu.Item>
-          <Button type="link" onClick={() => changeLanguage('en')}>
-            {t('english')}
-          </Button>
-        </Menu.Item>
+        <Button onClick={() => changeLanguage('en')}>{t('english')}</Button>
       ) : (
+        <Button onClick={() => changeLanguage('es')}>{t('spanish')}</Button>
+      )}
+      <Button type="link" onClick={logout}>
+        {t('logout')}
+      </Button>
+    </>
+  )
+
+  const renderMobileMenu = () => {
+    const mobileMenu = (
+      <Menu>
+        {i18n.language === 'es' ? (
+          <Menu.Item>
+            <Button type="link" onClick={() => changeLanguage('en')}>
+              {t('english')}
+            </Button>
+          </Menu.Item>
+        ) : (
+          <Menu.Item>
+            <Button type="link" onClick={() => changeLanguage('es')}>
+              {t('spanish')}
+            </Button>
+          </Menu.Item>
+        )}
         <Menu.Item>
-          <Button type="link" onClick={() => changeLanguage('es')}>
-            {t('spanish')}
+          <Button type="link" onClick={logout}>
+            {t('logout')}
           </Button>
         </Menu.Item>
-      )}
-      <Menu.Item>
-        <Button type="link" onClick={logout}>
-          {t('logout')}
-        </Button>
-      </Menu.Item>
-    </Menu>
-  )
+      </Menu>
+    )
+
+    return (
+      <Dropdown overlay={mobileMenu}>
+        <MenuOutlined />
+      </Dropdown>
+    )
+  }
+
+  useEffect(() => {
+    window.addEventListener('resize', setWidth)
+
+    return () => window.removeEventListener('resize', setWidth)
+  }, [])
 
   return (
     <div className="bg-mediumGray">
@@ -62,26 +91,7 @@ export function LoggedInLayout({ children, title }) {
         >
           Pie for Providers
         </div>
-        {screens.md ? (
-          <>
-            {i18n.language === 'es' ? (
-              <Button onClick={() => changeLanguage('en')}>
-                {t('english')}
-              </Button>
-            ) : (
-              <Button onClick={() => changeLanguage('es')}>
-                {t('spanish')}
-              </Button>
-            )}
-            <Button type="link" onClick={logout}>
-              {t('logout')}
-            </Button>
-          </>
-        ) : (
-          <Dropdown overlay={mobileMenu}>
-            <MenuOutlined />
-          </Dropdown>
-        )}
+        {windowWidth > 768 ? renderDesktopMenu() : renderMobileMenu()}
       </div>
       <div className="w-full xs:h-full px-4 mt-4">
         {title && (


### PR DESCRIPTION
#248  💅🏼 What issue does this fix? fix nav bar responsiveness to use hamburger menu at <= 768px
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  DO NOT use "Fixes #123" or anything that will auto-close the ticket, we want the ticket open until it's QAed. -->

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [ ] Did you run `yarn lint` in `/client`?
* [ ] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🏺 Accessibility
<!-- Did you find any accessibility issues in your UI components?  Did you mitigate them?  If not, link the bug tickets you filed for mitigation. -->

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
