### PR TITLE
697/sorting for table columns

### DIFF
--- a/client/src/Dashboard/DashboardTable.js
+++ b/client/src/Dashboard/DashboardTable.js
@@ -9,7 +9,7 @@ import '_assets/styles/tag-overrides.css'
 
 export default function DashboardTable({ tableData, userState }) {
   const { t } = useTranslation()
-
+  const columnSorter = (a, b, name) => a[name] < b[name] ? -1 : a[name] > b[name] ? 1 : 0
   const onHeaderCell = () => {
     return {
       style: {
@@ -19,9 +19,6 @@ export default function DashboardTable({ tableData, userState }) {
       role: 'columnheader'
     }
   }
-
-  const columnSorter = (a, b, name) =>
-    a[name] < b[name] ? -1 : a[name] > b[name] ? 1 : 0
 
   const renderAttendanceRate = attendanceRate => {
     const createTag = (color, text) => (
@@ -75,21 +72,52 @@ export default function DashboardTable({ tableData, userState }) {
   }
 
   const neColConfig = [
-    { children: [{ name: 'child', render: renderChild, width: 250 }] },
+    {
+      children: [
+        {
+          name: 'child',
+          render: renderChild,
+          width: 250,
+          sorter: (a, b) => columnSorter(a.child, b.child, 'childName')
+        }
+      ]
+    },
     {
       name: 'attendance',
       children: [
-        { name: 'fullDays', sorter: (a, b) => columnSorter(a, b, 'fullDays') },
-        { name: 'hours', sorter: (a, b) => columnSorter(a, b, 'hours') },
-        { name: 'absences', sorter: (a, b) => columnSorter(a, b, 'absences') }
+        {
+          name: 'fullDays',
+          sorter: (a, b) =>
+            a.fullDays.match(/^\d+/)[0] - b.fullDays.match(/^\d+/)[0]
+        },
+        {
+          name: 'hours',
+          sorter: (a, b) => a.hours.match(/^\d+/)[0] - b.hours.match(/^\d+/)[0]
+        },
+        {
+          name: 'absences',
+          sorter: (a, b) =>
+            a.absences.match(/^\d+/)[0] - b.absences.match(/^\d+/)[0]
+        }
       ]
     },
     {
       name: 'revenue',
       children: [
-        { name: 'earnedRevenue' },
-        { name: 'estimatedRevenue' },
-        { name: 'transportationRevenue' }
+        {
+          name: 'earnedRevenue',
+          sorter: (a, b) => a.earnedRevenue - b.earnedRevenue
+        },
+        {
+          name: 'estimatedRevenue',
+          sorter: (a, b) => a.estimatedRevenue - b.estimatedRevenue
+        },
+        {
+          name: 'transportationRevenue',
+          sorter: (a, b) =>
+            a.transportationRevenue.match(/([0-9]+.[0-9]{2})/)[0] -
+            b.transportationRevenue.match(/([0-9]+.[0-9]{2})/)[0]
+        }
       ]
     }
   ]

--- a/client/src/Dashboard/DashboardTable.js
+++ b/client/src/Dashboard/DashboardTable.js
@@ -9,7 +9,8 @@ import '_assets/styles/tag-overrides.css'
 
 export default function DashboardTable({ tableData, userState }) {
   const { t } = useTranslation()
-  const columnSorter = (a, b, name) => a[name] < b[name] ? -1 : a[name] > b[name] ? 1 : 0
+  const columnSorter = (a, b, name) =>
+    a[name] < b[name] ? -1 : a[name] > b[name] ? 1 : 0
   const onHeaderCell = () => {
     return {
       style: {
@@ -71,87 +72,88 @@ export default function DashboardTable({ tableData, userState }) {
     })
   }
 
-  const neColConfig = [
-    {
-      children: [
-        {
-          name: 'child',
-          render: renderChild,
-          width: 250,
-          sorter: (a, b) => columnSorter(a.child, b.child, 'childName')
-        }
-      ]
-    },
-    {
-      name: 'attendance',
-      children: [
-        {
-          name: 'fullDays',
-          sorter: (a, b) =>
-            a.fullDays.match(/^\d+/)[0] - b.fullDays.match(/^\d+/)[0]
-        },
-        {
-          name: 'hours',
-          sorter: (a, b) => a.hours.match(/^\d+/)[0] - b.hours.match(/^\d+/)[0]
-        },
-        {
-          name: 'absences',
-          sorter: (a, b) =>
-            a.absences.match(/^\d+/)[0] - b.absences.match(/^\d+/)[0]
-        }
-      ]
-    },
-    {
-      name: 'revenue',
-      children: [
-        {
-          name: 'earnedRevenue',
-          sorter: (a, b) => a.earnedRevenue - b.earnedRevenue
-        },
-        {
-          name: 'estimatedRevenue',
-          sorter: (a, b) => a.estimatedRevenue - b.estimatedRevenue
-        },
-        {
-          name: 'transportationRevenue',
-          sorter: (a, b) =>
-            a.transportationRevenue.match(/([0-9]+.[0-9]{2})/)[0] -
-            b.transportationRevenue.match(/([0-9]+.[0-9]{2})/)[0]
-        }
-      ]
-    }
-  ]
-
-  const defaultColConfig = [
-    { name: 'childName', sorter: (a, b) => columnSorter(a, b, 'childName') },
-    { name: 'cNumber', sorter: (a, b) => columnSorter(a, b, 'cNumber') },
-    { name: 'business', sorter: (a, b) => columnSorter(a, b, 'business') },
-    {
-      name: 'attendanceRate',
-      sorter: (a, b) => a.attendanceRate.rate - b.attendanceRate.rate,
-      render: renderAttendanceRate
-    },
-    {
-      name: 'guaranteedRevenue',
-      sorter: (a, b) => a.guaranteedRevenue - b.guaranteedRevenue
-    },
-    {
-      name: 'potentialRevenue',
-      sorter: (a, b) => a.potentialRevenue - b.potentialRevenue
-    },
-    {
-      name: 'maxApprovedRevenue',
-      sorter: (a, b) => a.maxApprovedRevenue - b.maxApprovedRevenue
-    }
-  ]
+  const columnConfig = {
+    ne: [
+      {
+        children: [
+          {
+            name: 'child',
+            render: renderChild,
+            width: 250,
+            sorter: (a, b) => columnSorter(a.child, b.child, 'childName')
+          }
+        ]
+      },
+      {
+        name: 'attendance',
+        children: [
+          {
+            name: 'fullDays',
+            sorter: (a, b) =>
+              a.fullDays.match(/^\d+/)[0] - b.fullDays.match(/^\d+/)[0]
+          },
+          {
+            name: 'hours',
+            sorter: (a, b) => a.hours.match(/^\d+/)[0] - b.hours.match(/^\d+/)[0]
+          },
+          {
+            name: 'absences',
+            sorter: (a, b) =>
+              a.absences.match(/^\d+/)[0] - b.absences.match(/^\d+/)[0]
+          }
+        ]
+      },
+      {
+        name: 'revenue',
+        children: [
+          {
+            name: 'earnedRevenue',
+            sorter: (a, b) => a.earnedRevenue - b.earnedRevenue
+          },
+          {
+            name: 'estimatedRevenue',
+            sorter: (a, b) => a.estimatedRevenue - b.estimatedRevenue
+          },
+          {
+            name: 'transportationRevenue',
+            sorter: (a, b) =>
+              a.transportationRevenue.match(/([0-9]+.[0-9]{2})/)[0] -
+              b.transportationRevenue.match(/([0-9]+.[0-9]{2})/)[0]
+          }
+        ]
+      }
+    ],
+    default: [
+      { name: 'childName', sorter: (a, b) => columnSorter(a, b, 'childName') },
+      { name: 'cNumber', sorter: (a, b) => columnSorter(a, b, 'cNumber') },
+      { name: 'business', sorter: (a, b) => columnSorter(a, b, 'business') },
+      {
+        name: 'attendanceRate',
+        sorter: (a, b) => a.attendanceRate.rate - b.attendanceRate.rate,
+        render: renderAttendanceRate
+      },
+      {
+        name: 'guaranteedRevenue',
+        sorter: (a, b) => a.guaranteedRevenue - b.guaranteedRevenue
+      },
+      {
+        name: 'potentialRevenue',
+        sorter: (a, b) => a.potentialRevenue - b.potentialRevenue
+      },
+      {
+        name: 'maxApprovedRevenue',
+        sorter: (a, b) => a.maxApprovedRevenue - b.maxApprovedRevenue
+      }
+    ]
+  }
 
   return (
     <Table
       dataSource={tableData}
       columns={
         userState === 'NE'
-          ? generateColumns(neColConfig)
-          : generateColumns(defaultColConfig)
+          ? generateColumns(columnConfig['ne'])
+          : generateColumns(columnConfig['default'])
       }
       bordered={true}
       size={'medium'}

--- a/client/src/Dashboard/DashboardTable.js
+++ b/client/src/Dashboard/DashboardTable.js
@@ -9,8 +9,7 @@ import '_assets/styles/tag-overrides.css'
 
 export default function DashboardTable({ tableData, userState }) {
   const { t } = useTranslation()
-  const columnSorter = (a, b, name) =>
-    a[name] < b[name] ? -1 : a[name] > b[name] ? 1 : 0
+  const columnSorter = (a, b) => (a < b ? -1 : a > b ? 1 : 0)
   const onHeaderCell = () => {
     return {
       style: {
@@ -80,7 +79,11 @@ export default function DashboardTable({ tableData, userState }) {
             name: 'child',
             render: renderChild,
             width: 250,
-            sorter: (a, b) => columnSorter(a.child, b.child, 'childName')
+            sorter: (a, b) =>
+              columnSorter(
+                a.child.childName.match(/([A-zÀ-ú])+$/)[0],
+                b.child.childName.match(/([A-zÀ-ú])+$/)[0]
+              )
           }
         ]
       },
@@ -94,7 +97,8 @@ export default function DashboardTable({ tableData, userState }) {
           },
           {
             name: 'hours',
-            sorter: (a, b) => a.hours.match(/^\d+/)[0] - b.hours.match(/^\d+/)[0]
+            sorter: (a, b) =>
+              a.hours.match(/^\d+/)[0] - b.hours.match(/^\d+/)[0]
           },
           {
             name: 'absences',
@@ -124,9 +128,15 @@ export default function DashboardTable({ tableData, userState }) {
       }
     ],
     default: [
-      { name: 'childName', sorter: (a, b) => columnSorter(a, b, 'childName') },
-      { name: 'cNumber', sorter: (a, b) => columnSorter(a, b, 'cNumber') },
-      { name: 'business', sorter: (a, b) => columnSorter(a, b, 'business') },
+      {
+        name: 'childName',
+        sorter: (a, b) => columnSorter(a.childName, b.childName)
+      },
+      { name: 'cNumber', sorter: (a, b) => columnSorter(a.cNumber, b.cNumber) },
+      {
+        name: 'business',
+        sorter: (a, b) => columnSorter(a.business, b.business)
+      },
       {
         name: 'attendanceRate',
         sorter: (a, b) => a.attendanceRate.rate - b.attendanceRate.rate,


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
#577 this is work to follow-up on the nebraska table. earlier work left out sorters for all columns and the specific logic needed for some columns. 
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  DO NOT use "Fixes #123" or anything that will auto-close the ticket, we want the ticket open until it's QAed. -->

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [x ] Did you run `yarn lint` in `/client`?
* [ x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🏺 Accessibility
<!-- Did you find any accessibility issues in your UI components?  Did you mitigate them?  If not, link the bug tickets you filed for mitigation. -->

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
This PR adds sorting functionality to each of the NE dashboard table's columns. Per conversation with @csprayregen the columns should be sortable as follows: 
-- Child: sorts by last name
-- Full days, Hours, Absences: sorts by the first digit in the 'num of num' string
-- Earned Revenue, Estimated Revenue: nothing special, regular number sorting
-- Transportation revenue: sorts using the dollar amount

<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
