### PR TITLE
Revert "Bump pgreset from 0.1.1 to 0.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :development do
   gem 'guard-rspec', require: false
   gem 'letter_opener_web', '~> 1.4'
   gem 'listen', '>= 3.0.5', '< 3.5'
-  gem 'pgreset'
+  # gem 'pgreset' # currently has a bug with rails 6.1.0, removing from the dev bundle until it's fixed
   gem 'rails-erd'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
     parser (3.0.0.0)
       ast (~> 2.4.1)
     pg (1.2.3)
-    pgreset (0.2)
+    pgreset (0.1.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,6 @@ GEM
     parser (3.0.0.0)
       ast (~> 2.4.1)
     pg (1.2.3)
-    pgreset (0.1.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -371,7 +370,6 @@ DEPENDENCIES
   mocha
   money-rails
   pg (>= 0.18, < 2.0)
-  pgreset
   pry
   pry-remote
   puma (~> 5.1)


### PR DESCRIPTION
Reverts pieforproviders/pieforproviders#785 - there's currently a bug in pgreset that is preventing db resets