### PR TITLE
configure as of figure and static date filter number and render

### DIFF
--- a/client/src/Dashboard/Dashboard.js
+++ b/client/src/Dashboard/Dashboard.js
@@ -278,7 +278,7 @@ export function Dashboard() {
           <Typography.Title className="dashboard-title mr-4">
             {t('dashboardTitle')}
           </Typography.Title>
-          <Button className="date-filter-button mr-2 text-base py-2 px-4">
+          <Button className="date-filter-button mr-2 text-base py-2 px-4" disabled>
             {dates.dateFilter}
           </Button>
           <Typography.Text className="text-gray3">{`As of: ${dates.asOf}`}</Typography.Text>

--- a/client/src/Dashboard/Dashboard.js
+++ b/client/src/Dashboard/Dashboard.js
@@ -200,34 +200,8 @@ export function Dashboard() {
   }
 
   const reduceAsOfDate = res => {
-    const practice = [
-      {
-        as_of: '01/21/2020',
-        businesses: Array(1),
-        max_revenue: 23122,
-        total_approved: 23122
-      },
-      {
-        as_of: '01/21/2021',
-        businesses: Array(1),
-        max_revenue: 23122,
-        total_approved: 23122
-      },
-      {
-        as_of: '01/11/2021',
-        businesses: Array(1),
-        max_revenue: 23122,
-        total_approved: 23122
-      },
-      {
-        as_of: '12/21/2020',
-        businesses: Array(1),
-        max_revenue: 23122,
-        total_approved: 23122
-      }
-    ]
     const date = new Date(
-      practice.reduce((user1, user2) => {
+      res.reduce((user1, user2) => {
         return new Date(user1.as_of) > new Date(user2.as_of) ? user1 : user2
       }).as_of
     )

--- a/client/src/Dashboard/Dashboard.js
+++ b/client/src/Dashboard/Dashboard.js
@@ -2,10 +2,11 @@ import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useApiResponse } from '_shared/_hooks/useApiResponse'
 import { useDispatch, useSelector } from 'react-redux'
-import { Typography } from 'antd'
+import { Button, Typography } from 'antd'
 import { setUser } from '_reducers/userReducer'
 import DashboardStats from './DashboardStats'
 import DashboardTable from './DashboardTable'
+import '_assets/styles/dashboard-overrides.css'
 
 export function Dashboard() {
   const dispatch = useDispatch()
@@ -39,6 +40,7 @@ export function Dashboard() {
   )
   const [summaryData, setSummaryData] = useState([])
   const [tableData, setTableData] = useState([])
+  const [dates, setDates] = useState({ asOf: '', dateFilter: '' })
   const { makeRequest } = useApiResponse()
   const { t, i18n } = useTranslation()
 
@@ -197,6 +199,51 @@ export function Dashboard() {
     }, summaryDataTotalsConfig['default'])
   }
 
+  const reduceAsOfDate = res => {
+    const practice = [
+      {
+        as_of: '01/21/2020',
+        businesses: Array(1),
+        max_revenue: 23122,
+        total_approved: 23122
+      },
+      {
+        as_of: '01/21/2021',
+        businesses: Array(1),
+        max_revenue: 23122,
+        total_approved: 23122
+      },
+      {
+        as_of: '01/11/2021',
+        businesses: Array(1),
+        max_revenue: 23122,
+        total_approved: 23122
+      },
+      {
+        as_of: '12/21/2020',
+        businesses: Array(1),
+        max_revenue: 23122,
+        total_approved: 23122
+      }
+    ]
+    const date = new Date(
+      practice.reduce((user1, user2) => {
+        return new Date(user1.as_of) > new Date(user2.as_of) ? user1 : user2
+      }).as_of
+    )
+
+    return {
+      asOf: date.toLocaleDateString('default', {
+        month: 'short',
+        day: 'numeric'
+      }),
+      dateFilter: new Date().toLocaleDateString('default', {
+        month: 'short',
+        year: 'numeric'
+      })
+    }
+  }
+
   useEffect(() => {
     const getUserData = async () => {
       const response = await makeRequest({
@@ -230,6 +277,7 @@ export function Dashboard() {
           tableData,
           parsedResponse
         )
+        setDates(reduceAsOfDate(parsedResponse))
         setSummaryTotals(updatedSummaryDataTotals)
         setSummaryData(generateSummaryData(tableData, updatedSummaryDataTotals))
         setTableData(tableData)
@@ -252,7 +300,15 @@ export function Dashboard() {
   return (
     <div className="dashboard sm:mx-8">
       <div className="dashboard-title m-2">
-        <Typography.Title>{t('dashboardTitle')}</Typography.Title>
+        <div className="flex items-center mb-3">
+          <Typography.Title className="dashboard-title mr-4">
+            {t('dashboardTitle')}
+          </Typography.Title>
+          <Button className="date-filter-button mr-2 text-base py-2 px-4">
+            {dates.dateFilter}
+          </Button>
+          <Typography.Text className="text-gray3">{`As of: ${dates.asOf}`}</Typography.Text>
+        </div>
         <Typography.Text className="md-3 text-base">
           {t('revenueProjections')}
         </Typography.Text>

--- a/client/src/Dashboard/Dashboard.js
+++ b/client/src/Dashboard/Dashboard.js
@@ -278,7 +278,10 @@ export function Dashboard() {
           <Typography.Title className="dashboard-title mr-4">
             {t('dashboardTitle')}
           </Typography.Title>
-          <Button className="date-filter-button mr-2 text-base py-2 px-4" disabled>
+          <Button
+            className="date-filter-button mr-2 text-base py-2 px-4"
+            disabled
+          >
             {dates.dateFilter}
           </Button>
           <Typography.Text className="text-gray3">{`As of: ${dates.asOf}`}</Typography.Text>

--- a/client/src/_assets/styles/dashboard-overrides.css
+++ b/client/src/_assets/styles/dashboard-overrides.css
@@ -1,0 +1,12 @@
+.dashboard-title.ant-typography {
+  margin-bottom: 0;
+}
+
+button.ant-btn:hover {
+  color: #333333;
+  border-color: #d9d9d9;
+}
+
+button.ant-btn {
+  height: 38px;
+}

--- a/client/src/_assets/styles/dashboard-overrides.css
+++ b/client/src/_assets/styles/dashboard-overrides.css
@@ -2,11 +2,11 @@
   margin-bottom: 0;
 }
 
-button.ant-btn:hover {
+button.ant-btn.date-filter-button:hover, button.ant-btn.date-filter-button:disabled {
   color: #333333;
   border-color: #d9d9d9;
 }
 
-button.ant-btn {
+button.ant-btn.date-filter-button {
   height: 38px;
 }


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
#677
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  DO NOT use "Fixes #123" or anything that will auto-close the ticket, we want the ticket open until it's QAed. -->

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🏺 Accessibility
<!-- Did you find any accessibility issues in your UI components?  Did you mitigate them?  If not, link the bug tickets you filed for mitigation. -->

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
login with both IL and NE users and confirm that a date filter button with static data showing the current month renders in the dashboard title and an 'as of' data point configured from the user data from API
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
