### PR TITLE
add as of and month translations

### DIFF
--- a/client/src/Dashboard/Dashboard.js
+++ b/client/src/Dashboard/Dashboard.js
@@ -44,6 +44,11 @@ export function Dashboard() {
   const { makeRequest } = useApiResponse()
   const { t, i18n } = useTranslation()
 
+  const matchAndReplaceDate = dateString => {
+    const match = dateString.match(/^[A-Za-z]+/)
+    return match ? dateString.replace(match[0], t(match[0].toLowerCase())) : ''
+  }
+
   const generateSummaryData = (td = tableData, totals = summaryDataTotals) => {
     if (user.state === 'NE' && totals.earnedRevenueTotal >= 0) {
       return [
@@ -282,9 +287,11 @@ export function Dashboard() {
             className="date-filter-button mr-2 text-base py-2 px-4"
             disabled
           >
-            {dates.dateFilter}
+            {matchAndReplaceDate(dates.dateFilter)}
           </Button>
-          <Typography.Text className="text-gray3">{`As of: ${dates.asOf}`}</Typography.Text>
+          <Typography.Text className="text-gray3">{`${t(
+            `asOf`
+          )}: ${matchAndReplaceDate(dates.asOf)}`}</Typography.Text>
         </div>
         <Typography.Text className="md-3 text-base">
           {t('revenueProjections')}

--- a/client/src/i18n/locales/en/index.json
+++ b/client/src/i18n/locales/en/index.json
@@ -171,5 +171,19 @@
   "atRisk": "at risk",
   "notMet": "not met",
   "notEnoughInfo": "not enough info",
-  "exceededLimit": "exceeded limit"
+  "exceededLimit": "exceeded limit",
+
+  "asOf": "As of",
+  "jan": "Jan",
+  "feb": "Feb",
+  "mar": "Mar",
+  "apr": "Apr",
+  "may": "May",
+  "jun": "Jun",
+  "jul": "Jul",
+  "aug": "Aug",
+  "sept": "Sept",
+  "oct": "Oct",
+  "nov": "Nov",
+  "dec": "Dec"
 }

--- a/client/src/i18n/locales/es/index.json
+++ b/client/src/i18n/locales/es/index.json
@@ -171,5 +171,19 @@
   "atRisk": "en riesgo",
   "notMet": "no cumplido",
   "notEnoughInfo": "información insuficiente",
-  "exceededLimit": "excedió el límite"
+  "exceededLimit": "excedió el límite",
+
+  "asOf": "A partir de",
+  "jan": "Enero",
+  "feb": "Feb",
+  "mar": "Marzo",
+  "apr": "Abr",
+  "may": "Mayo",
+  "jun": "Jun",
+  "jul": "Jul",
+  "aug": "Agosto",
+  "sept": "Set",
+  "oct": "Oct",
+  "nov": "Nov",
+  "dec": "Dic"
 }


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
related to #677 -- adds translations for 'as of' and months
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  DO NOT use "Fixes #123" or anything that will auto-close the ticket, we want the ticket open until it's QAed. -->

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [ x] Did you run `yarn lint` in `/client`?
* [ x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🏺 Accessibility
<!-- Did you find any accessibility issues in your UI components?  Did you mitigate them?  If not, link the bug tickets you filed for mitigation. -->

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
confirm that 'As of' and months switch back and forth between english and spanish. (challenging to test currently, since the month is Feb and test data for 'as of' also uses feb, since spanish and english abbreviations for Feb are the same. may want to add a different month for 'As of' test data @katelovescode for QA purposes )
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
