### PR TITLE
[965] Adds temporary ne dash rake task

### DIFF
--- a/lib/tasks/temporary_ne_dash.rake
+++ b/lib/tasks/temporary_ne_dash.rake
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# This is meant to simulate someone entering dashboard data on any
+# given day of the month; it should work multiple times a month
+desc 'Generate attendances this month'
+task temporary_ne_dash: :environment do
+  if ENV.fetch('ALLOW_SEEDING', 'false') == 'true'
+    generate_dashboard
+  else
+    puts 'Error seeding dashboard: this environment does not allow for seeding dashboard'
+  end
+end
+
+def generate_dashboard
+  Child.includes(:business).where(business: { state: 'NE' }).each do |child|
+    total_absences = rand(0..10).round
+    total_days = rand(0..25).round
+    total_hours = rand(0.0..10.0).round
+
+    TemporaryNebraskaDashboardCase.find_or_initialize_by(child: child).update!(
+      attendance_risk: %w[on_track exceeded_limit ahead_of_schedule at_risk].sample,
+      absences: "#{rand(0..total_absences)} of #{total_absences}",
+      earned_revenue: rand(0.00..1000.00).round(2),
+      estimated_revenue: rand(1000.00..2000.00).round(2),
+      full_days: "#{rand(0..total_days)} of #{total_days}",
+      hours: "#{rand(0.0..total_hours).round(2)} of #{total_hours}",
+      transportation_revenue: "#{rand(0..30)} trips - #{Money.new(rand(0..100_000)).format}"
+    )
+  end
+end

--- a/lib/tasks/temporary_ne_dash.rake
+++ b/lib/tasks/temporary_ne_dash.rake
@@ -11,14 +11,12 @@ task temporary_ne_dash: :environment do
   end
 end
 
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/MethodLength
 def generate_dashboard
-  Child.includes(:business).where(business: { state: 'NE' }).each do |child|
-    total_absences = rand(0..10).round
-    total_days = rand(0..25).round
-    total_hours = rand(0.0..10.0).round
-
+  Child.includes(:business).where(business: { state: 'NE' }).each_with_index do |child, index|
     TemporaryNebraskaDashboardCase.find_or_initialize_by(child: child).update!(
-      attendance_risk: %w[on_track exceeded_limit ahead_of_schedule at_risk].sample,
+      attendance_risk: attendance_risk[index],
       absences: "#{rand(0..total_absences)} of #{total_absences}",
       earned_revenue: rand(0.00..1000.00).round(2),
       estimated_revenue: rand(1000.00..2000.00).round(2),
@@ -27,4 +25,22 @@ def generate_dashboard
       transportation_revenue: "#{rand(0..30)} trips - #{Money.new(rand(0..100_000)).format}"
     )
   end
+end
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/AbcSize
+
+def total_absences
+  rand(0..10).round
+end
+
+def total_days
+  rand(0..25).round
+end
+
+def total_hours
+  rand(0.0..10.0).round
+end
+
+def attendance_risk
+  %w[on_track exceeded_limit ahead_of_schedule at_risk]
 end


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
#965 - adds a rake task to run on staging (we had populated this data before using a data migration but were missing a status option, so this rake task will let us update and re-run dashboard data population on staging at any time

## 🧵 Steps to set up locally

## 🧳 Steps to test

Run the rake task; your Nebraska kids should get new dash data, randomized
