### PR TITLE
[929] API accepts date for dashboard

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,17 +1,14 @@
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
-  - title: '🚀 Features'
+  - title: '👒 Dependencies'
     labels:
-      - 'feature'
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
+      - 'dependencies'
+  - title: '🏕 Backend'
     labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
-  - title: '🧰 Maintenance'
-    label: 'chore'
+      - 'backend'
+  - title: '🪔 Frontend'
+    label: 'frontend'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:

--- a/app/blueprints/business_blueprint.rb
+++ b/app/blueprints/business_blueprint.rb
@@ -8,7 +8,7 @@ class BusinessBlueprint < Blueprinter::Base
     field :name
     exclude :id
     association :children, name: :cases, blueprint: ChildBlueprint, view: :illinois_dashboard do |business, options|
-      business.children.active.approved_for_date(options[:from_date], options[:timezone])
+      business.children.active.approved_for_date(options[:filter_date], options[:timezone])
     end
   end
 
@@ -16,7 +16,7 @@ class BusinessBlueprint < Blueprinter::Base
     field :name
     exclude :id
     association :children, name: :cases, blueprint: ChildBlueprint, view: :nebraska_dashboard do |business, options|
-      business.children.active.approved_for_date(options[:from_date], options[:timezone])
+      business.children.active.approved_for_date(options[:filter_date], options[:timezone])
     end
   end
 end

--- a/app/blueprints/child_blueprint.rb
+++ b/app/blueprints/child_blueprint.rb
@@ -7,13 +7,13 @@ class ChildBlueprint < Blueprinter::Base
   view :illinois_dashboard do
     field :full_name
     field :case_number do |child, options|
-      child.approvals.active_on_date(options[:from_date].in_time_zone(child.timezone)).first.case_number
+      child.approvals.active_on_date(options[:filter_date].in_time_zone(child.timezone)).first.case_number
     end
     field :attendance_risk do |child, options|
-      child.attendance_risk(options[:from_date])
+      child.attendance_risk(options[:filter_date])
     end
     field(:attendance_rate) do |child, options|
-      child.attendance_rate(options[:from_date])
+      child.attendance_rate(options[:filter_date])
     end
     field :guaranteed_revenue do |_child, _options|
       rand(0.00..500.00).round(2)
@@ -35,7 +35,7 @@ class ChildBlueprint < Blueprinter::Base
       child.temporary_nebraska_dashboard_case&.absences
     end
     field :case_number do |child, options|
-      child.approvals.active_on_date(options[:from_date].in_time_zone(child.timezone)).first.case_number
+      child.approvals.active_on_date(options[:filter_date].in_time_zone(child.timezone)).first.case_number
     end
     field :earned_revenue do |child|
       child.temporary_nebraska_dashboard_case&.earned_revenue&.to_f || 0.0

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -12,7 +12,7 @@ class UserBlueprint < Blueprinter::Base
   view :illinois_dashboard do
     field(:as_of) do |user, options|
       # if there are no attendances, the rates are as of today
-      (user.latest_attendance_in_month(options[:from_date]) || DateTime.now.in_time_zone(user.timezone)).strftime('%m/%d/%Y')
+      (user.latest_attendance_in_month(options[:filter_date]) || DateTime.now.in_time_zone(user.timezone)).strftime('%m/%d/%Y')
     end
     association :businesses, blueprint: BusinessBlueprint, view: :illinois_dashboard
     excludes :id, :greeting_name, :language, :state
@@ -21,7 +21,7 @@ class UserBlueprint < Blueprinter::Base
   view :nebraska_dashboard do
     field(:as_of) do |user, options|
       # if there are no attendances, the rates are as of today
-      (user.latest_attendance_in_month(options[:from_date]) || DateTime.now.in_time_zone(user.timezone)).strftime('%m/%d/%Y')
+      (user.latest_attendance_in_month(options[:filter_date]) || DateTime.now.in_time_zone(user.timezone)).strftime('%m/%d/%Y')
     end
     association :businesses, blueprint: BusinessBlueprint, view: :nebraska_dashboard
     field :max_revenue do

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -28,15 +28,19 @@ module Api
 
       private
 
-      def date_now
-        DateTime.now.in_time_zone(current_user.timezone)
+      def filter_date
+        if params[:filter_date]
+          Date.parse(params[:filter_date])&.in_time_zone(current_user.timezone)&.at_end_of_day
+        else
+          DateTime.now.in_time_zone(current_user.timezone)
+        end
       end
 
       def nebraska_dashboard
         UserBlueprint.render(
           policy_scope(User),
           view: :nebraska_dashboard,
-          from_date: date_now,
+          filter_date: filter_date,
           timezone: current_user.timezone
         )
       end
@@ -45,7 +49,7 @@ module Api
         UserBlueprint.render(
           policy_scope(User),
           view: :illinois_dashboard,
-          from_date: date_now,
+          filter_date: filter_date,
           timezone: current_user.timezone
         )
       end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -52,12 +52,12 @@ class Child < UuidApplicationRecord
     IllinoisApprovalAmount.where(child_approval: ChildApproval.where(child: self))
   end
 
-  def attendance_rate(from_date)
-    AttendanceRateCalculator.new(self, from_date.in_time_zone(timezone)).call
+  def attendance_rate(filter_date)
+    AttendanceRateCalculator.new(self, filter_date.in_time_zone(timezone)).call
   end
 
-  def attendance_risk(from_date)
-    AttendanceRiskCalculator.new(self, from_date.in_time_zone(timezone)).call
+  def attendance_risk(filter_date)
+    AttendanceRiskCalculator.new(self, filter_date.in_time_zone(timezone)).call
   end
 
   private

--- a/app/models/illinois_approval_amount.rb
+++ b/app/models/illinois_approval_amount.rb
@@ -7,7 +7,7 @@ class IllinoisApprovalAmount < UuidApplicationRecord
   validates :part_days_approved_per_week, numericality: true, allow_nil: true
   validates :full_days_approved_per_week, numericality: true, allow_nil: true
 
-  scope :for_month, ->(date = DateTime.now) { find_by(month: date.at_beginning_of_month..date.at_end_of_month) }
+  scope :for_month, ->(date_time = DateTime.now) { where(month: date_time.at_beginning_of_month.to_date..date_time.at_end_of_month.to_date) }
 end
 
 # == Schema Information

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,9 +44,9 @@ class User < UuidApplicationRecord
     businesses&.first&.state || ''
   end
 
-  def latest_attendance_in_month(from_date)
-    from_date = from_date.in_time_zone(timezone)
-    Attendance.where('check_in BETWEEN ? AND ?', from_date.at_beginning_of_month, from_date.at_end_of_month)
+  def latest_attendance_in_month(filter_date)
+    filter_date = filter_date.in_time_zone(timezone)
+    Attendance.where('check_in BETWEEN ? AND ?', filter_date.at_beginning_of_month, filter_date.at_end_of_month)
               .where(child_approval: ChildApproval.where(child: Child.where(business: Business.where(user: self))))
               .max_by(&:check_in)&.check_in&.in_time_zone(timezone)
   end

--- a/app/services/attendance_rate_calculator.rb
+++ b/app/services/attendance_rate_calculator.rb
@@ -2,9 +2,9 @@
 
 # Service to calculate a family's attendance rate
 class AttendanceRateCalculator
-  def initialize(child, from_date)
+  def initialize(child, filter_date)
     @child = child
-    @from_date = from_date
+    @filter_date = filter_date
     @state = child.business.state
   end
 
@@ -15,6 +15,6 @@ class AttendanceRateCalculator
   private
 
   def calculate_attendance_rate
-    IllinoisAttendanceRateCalculator.new(@child, @from_date).call if @state == 'IL'
+    IllinoisAttendanceRateCalculator.new(@child, @filter_date).call if @state == 'IL'
   end
 end

--- a/app/services/attendance_risk_calculator.rb
+++ b/app/services/attendance_risk_calculator.rb
@@ -2,9 +2,9 @@
 
 # Service to calculate a family's attendance rate
 class AttendanceRiskCalculator
-  def initialize(child, from_date)
+  def initialize(child, filter_date)
     @child = child
-    @from_date = from_date
+    @filter_date = filter_date
     @state = child.business.state
   end
 
@@ -15,6 +15,6 @@ class AttendanceRiskCalculator
   private
 
   def calculate_attendance_risk
-    IllinoisAttendanceRiskCalculator.new(@child, @from_date).call if @state == 'IL'
+    IllinoisAttendanceRiskCalculator.new(@child, @filter_date).call if @state == 'IL'
   end
 end

--- a/app/services/illinois_attendance_rate_calculator.rb
+++ b/app/services/illinois_attendance_rate_calculator.rb
@@ -2,9 +2,9 @@
 
 # Service to calculate a family's attendance rate
 class IllinoisAttendanceRateCalculator
-  def initialize(child, from_date)
+  def initialize(child, filter_date)
     @child = child
-    @from_date = from_date
+    @filter_date = filter_date
   end
 
   def call
@@ -32,14 +32,14 @@ class IllinoisAttendanceRateCalculator
   end
 
   def active_approval
-    @child.approvals.active_on_date(@from_date.in_time_zone(@child.timezone)).first
+    @child.approvals.active_on_date(@filter_date.in_time_zone(@child.timezone)).first
   end
 
   def sum_approvals(child)
-    approval_amount = child.illinois_approval_amounts.for_month(@from_date)
+    approval_amount = child.illinois_approval_amounts.for_month(@filter_date).first
     return 0 unless approval_amount
 
-    weeks_in_month = DateService.weeks_in_month(@from_date)
+    weeks_in_month = DateService.weeks_in_month(@filter_date)
 
     [
       approval_amount.part_days_approved_per_week * weeks_in_month,
@@ -48,7 +48,7 @@ class IllinoisAttendanceRateCalculator
   end
 
   def sum_attendances(child)
-    attendances = child.attendances.for_month
+    attendances = child.attendances.for_month(@filter_date)
     return 0 unless attendances
 
     [

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,7 @@ module App
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
-    config.autoload_paths << Rails.root.join('lib')
+    config.autoload_paths << Rails.root.join('lib').to_s
 
     config.active_record.schema_format = :ruby
 

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -37,7 +37,7 @@ if Rails.env.development?
       'ignore_model_sub_dir' => 'false',
       'ignore_columns' => nil,
       'ignore_routes' => nil,
-      'ignore_unknown_models' => 'false',
+      'ignore_unknown_models' => 'true',
       'hide_limit_column_types' => 'integer,bigint,boolean',
       'hide_default_column_types' => 'json,jsonb,hstore',
       'skip_on_db_migrate' => 'false',

--- a/lib/tasks/prep.rake
+++ b/lib/tasks/prep.rake
@@ -4,7 +4,6 @@ task prep: :environment do
   unless Rails.env.production?
     exec "yarn lint:fix &&
           yarn test-once &&
-          bundle exec rails erd annotate_models annotate_routes &&
           bundle exec rubocop -a &&
           bundle exec rspec &&
           bundle exec rails db:migrate:with_data &&

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -193,11 +193,13 @@ RSpec.describe 'users API', type: :request do
                 .active_child_approval(DateTime.now.in_time_zone(owner.timezone))
                 .illinois_approval_amounts
                 .for_month
+                .first
                 .update!(part_days_approved_per_week: 1, full_days_approved_per_week: 0)
               last_child
                 .active_child_approval(DateTime.now.in_time_zone(owner.timezone))
                 .illinois_approval_amounts
                 .for_month
+                .first
                 .update!(part_days_approved_per_week: 0, full_days_approved_per_week: 1)
               owner.businesses.first.children.each do |child|
                 current_child_approval = child.active_child_approval(DateTime.now.in_time_zone(owner.timezone))
@@ -227,11 +229,13 @@ RSpec.describe 'users API', type: :request do
                 .active_child_approval(DateTime.now.in_time_zone(owner.timezone))
                 .illinois_approval_amounts
                 .for_month
+                .first
                 .update!(part_days_approved_per_week: 1, full_days_approved_per_week: 2)
               last_child
                 .active_child_approval(DateTime.now.in_time_zone(owner.timezone))
                 .illinois_approval_amounts
                 .for_month
+                .first
                 .update!(part_days_approved_per_week: 0, full_days_approved_per_week: 1)
               owner.businesses.first.children.each do |child|
                 current_child_approval = child.active_child_approval(DateTime.now.in_time_zone(owner.timezone))
@@ -258,11 +262,13 @@ RSpec.describe 'users API', type: :request do
                 .active_child_approval(DateTime.now.in_time_zone(owner.timezone))
                 .illinois_approval_amounts
                 .for_month
+                .first
                 .update!(part_days_approved_per_week: 3, full_days_approved_per_week: 2)
               last_child
                 .active_child_approval(DateTime.now.in_time_zone(owner.timezone))
                 .illinois_approval_amounts
                 .for_month
+                .first
                 .update!(part_days_approved_per_week: 2, full_days_approved_per_week: 3)
               owner.businesses.first.children.each do |child|
                 current_child_approval = child.active_child_approval(DateTime.now.in_time_zone(owner.timezone))
@@ -292,11 +298,13 @@ RSpec.describe 'users API', type: :request do
                 .active_child_approval(DateTime.now.in_time_zone(owner.timezone))
                 .illinois_approval_amounts
                 .for_month
+                .first
                 .update!(part_days_approved_per_week: 3, full_days_approved_per_week: 2)
               last_child
                 .active_child_approval(DateTime.now.in_time_zone(owner.timezone))
                 .illinois_approval_amounts
                 .for_month
+                .first
                 .update!(part_days_approved_per_week: 2, full_days_approved_per_week: 3)
               owner.businesses.first.children.each do |child|
                 current_child_approval = child.active_child_approval(DateTime.now.in_time_zone(owner.timezone))
@@ -326,11 +334,13 @@ RSpec.describe 'users API', type: :request do
                 .active_child_approval(DateTime.now.in_time_zone(owner.timezone))
                 .illinois_approval_amounts
                 .for_month
+                .first
                 .update!(part_days_approved_per_week: 3, full_days_approved_per_week: 2)
               last_child
                 .active_child_approval(DateTime.now.in_time_zone(owner.timezone))
                 .illinois_approval_amounts
                 .for_month
+                .first
                 .update!(part_days_approved_per_week: 2, full_days_approved_per_week: 3)
               owner.businesses.first.children.each do |child|
                 current_child_approval = child.active_child_approval(DateTime.now.in_time_zone(owner.timezone))


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
#921 this adds a `filter_date` param to the controller so it can accept a date for the dashboard to use to display data for any given month.  It involves a little renaming and refactoring of a scope on illinois_approval_amounts so we can use scopes better (using `where` rather than `find_by` which is syntactically not really a scope)

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write tests?
* [X] Did you run `bundle exec rspec` from the root?
* [X] Did you run `bundle exec rails rswag` from the root?
* [X] Did you run `bundle exec rubocop` from the root?

## 🧳 Steps to test
- make sure you have approvals and attendances in the date you're going to test with
- hit the `/case_list_for_dashboard` endpoint with a date formatted `YYYY-MM-DD`
- you should see the correct data for that month

## 🕯 Caveats, concerns
**Caveat**: this will only work as expected in IL right now since NE isn't using calculations - cc @csprayregen 