### PR TITLE
Returns first_approval_effective_date

### DIFF
--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -14,6 +14,9 @@ class UserBlueprint < Blueprinter::Base
       # if there are no attendances, the rates are as of today
       (user.latest_attendance_in_month(options[:filter_date]) || DateTime.now.in_time_zone(user.timezone)).strftime('%m/%d/%Y')
     end
+    field(:first_approval_effective_date) do |user, _options|
+      user.first_approval_effective_date
+    end
     association :businesses, blueprint: BusinessBlueprint, view: :illinois_dashboard
     excludes :id, :greeting_name, :language, :state
   end
@@ -22,6 +25,9 @@ class UserBlueprint < Blueprinter::Base
     field(:as_of) do |user, options|
       # if there are no attendances, the rates are as of today
       (user.latest_attendance_in_month(options[:filter_date]) || DateTime.now.in_time_zone(user.timezone)).strftime('%m/%d/%Y')
+    end
+    field(:first_approval_effective_date) do |user, _options|
+      user.first_approval_effective_date
     end
     association :businesses, blueprint: BusinessBlueprint, view: :nebraska_dashboard
     field :max_revenue do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,10 @@ class User < UuidApplicationRecord
               .where(child_approval: ChildApproval.where(child: Child.where(business: Business.where(user: self))))
               .max_by(&:check_in)&.check_in&.in_time_zone(timezone)
   end
+
+  def first_approval_effective_date
+    approvals.order(effective_on: :asc).first.effective_on
+  end
 end
 
 # == Schema Information

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User < UuidApplicationRecord
   end
 
   def first_approval_effective_date
-    approvals.order(effective_on: :asc).first.effective_on
+    approvals.order(effective_on: :asc).first&.effective_on
   end
 end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     phone_number { Faker::PhoneNumber.phone_number }
     phone_type { %w[cell home work].sample }
     service_agreement_accepted { true }
-    timezone { TimeZoneService.us_zones.sample }
+    timezone { 'Central Time (US & Canada)' }
     confirmation_token { Faker::Alphanumeric.alphanumeric(number: 10) }
     confirmed_at { [Time.zone.at(rand * Time.now.to_i), nil].sample }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,19 @@ RSpec.describe User, type: :model do
   it 'formats a phone number with non-digit characters' do
     expect(user.phone_number).to eq('8888888888')
   end
+
+  describe '#first_approval_effective_date' do
+    let!(:business) { create(:business, user: user) }
+    let!(:approval1) { create(:approval, effective_on: Date.parse('Mar 3, 2020'), create_children: false) }
+    let!(:approval2) { create(:approval, effective_on: Date.parse('Jan 10, 2020'), create_children: false) }
+    let!(:approval3) { create(:approval, effective_on: Date.parse('May 6, 2020'), create_children: false) }
+    let!(:approval4) { create(:approval, effective_on: Date.parse('Feb 21, 2020'), create_children: false) }
+    let!(:child) { create(:child, business: business, approvals: [approval1, approval2, approval3]) }
+    let!(:child2) { create(:child, business: business, approvals: [approval4]) }
+    it 'returns the correct date' do
+      expect(user.first_approval_effective_date).to eq(Date.parse('Jan 10, 2020'))
+    end
+  end
 end
 
 # == Schema Information

--- a/spec/support/api/schemas/illinois_case_list_for_dashboard.json
+++ b/spec/support/api/schemas/illinois_case_list_for_dashboard.json
@@ -62,17 +62,17 @@
             "name"
           ]
         }
+      },
+      "first_approval_effective_date": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
       }
-    },
-    "first_approval_effective_date": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
     },
     "required": [
       "as_of",

--- a/spec/support/api/schemas/illinois_case_list_for_dashboard.json
+++ b/spec/support/api/schemas/illinois_case_list_for_dashboard.json
@@ -64,6 +64,16 @@
         }
       }
     },
+    "first_approval_effective_date": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "required": [
       "as_of",
       "businesses"

--- a/spec/support/api/schemas/nebraska_case_list_for_dashboard.json
+++ b/spec/support/api/schemas/nebraska_case_list_for_dashboard.json
@@ -133,6 +133,16 @@
           ]
         }
       },
+      "first_approval_effective_date": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
       "max_revenue": {
         "type": "decimal"
       },


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
#929 - wraps up returning the first approval date

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write tests?

## 🧳 Steps to test
hit /case_list_for_dashboard and the response should include a date for the first approval as `first_approval_effective_date`