### PR TITLE
Adds specs for blueprints

### DIFF
--- a/app/blueprints/child_blueprint.rb
+++ b/app/blueprints/child_blueprint.rb
@@ -7,7 +7,7 @@ class ChildBlueprint < Blueprinter::Base
   view :illinois_dashboard do
     field :full_name
     field :case_number do |child, options|
-      child.approvals.active_on_date(options[:filter_date]).first.case_number
+      child.approvals.active_on_date(options[:filter_date]).first&.case_number
     end
     field :attendance_risk do |child, options|
       child.attendance_risk(options[:filter_date])
@@ -35,7 +35,7 @@ class ChildBlueprint < Blueprinter::Base
       child.temporary_nebraska_dashboard_case&.absences
     end
     field :case_number do |child, options|
-      child.approvals.active_on_date(options[:filter_date]).first.case_number
+      child.approvals.active_on_date(options[:filter_date]).first&.case_number
     end
     field :earned_revenue do |child|
       child.temporary_nebraska_dashboard_case&.earned_revenue&.to_f || 0.0

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,7 @@ class User < UuidApplicationRecord
   end
 
   def latest_attendance_in_month(filter_date)
+    filter_date ||= Time.current
     # TODO: Fix this query using joins to eager load the child approvals and businesses
     Attendance.where('check_in BETWEEN ? AND ?', filter_date.at_beginning_of_month, filter_date.at_end_of_month)
               .where(child_approval: ChildApproval.where(child: Child.where(business: Business.where(user: self))))

--- a/app/services/illinois_attendance_rate_calculator.rb
+++ b/app/services/illinois_attendance_rate_calculator.rb
@@ -8,7 +8,7 @@ class IllinoisAttendanceRateCalculator
   end
 
   def call
-    return 0 unless family_days_approved.positive?
+    return 0 unless active_approval.presence && family_days_approved.positive?
 
     (family_days_attended.to_f / family_days_approved).round(3)
   end

--- a/app/services/illinois_attendance_risk_calculator.rb
+++ b/app/services/illinois_attendance_risk_calculator.rb
@@ -4,7 +4,7 @@
 class IllinoisAttendanceRiskCalculator
   def initialize(child, filter_date)
     @child = child
-    @filter_date = filter_date
+    @filter_date = filter_date || Time.current
   end
 
   def call

--- a/spec/blueprints/business_blueprint_spec.rb
+++ b/spec/blueprints/business_blueprint_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BusinessBlueprint do
+  let(:business) { create(:business) }
+  let(:blueprint) { BusinessBlueprint.render(business) }
+  context 'returns the correct fields when no view option is passed' do
+    it 'only includes the ID' do
+      expect(JSON.parse(blueprint).keys).to contain_exactly('id')
+    end
+  end
+  context 'returns the correct fields when IL view is requested' do
+    let(:blueprint) { BusinessBlueprint.render(business, view: :illinois_dashboard) }
+    it 'includes the business name and all cases' do
+      expect(JSON.parse(blueprint).keys).to contain_exactly(
+        'cases',
+        'name'
+      )
+    end
+  end
+  context 'returns the correct fields when NE view is requested' do
+    let(:blueprint) { BusinessBlueprint.render(business, view: :nebraska_dashboard) }
+    it 'includes the business name and all cases' do
+      expect(JSON.parse(blueprint).keys).to contain_exactly(
+        'cases',
+        'name'
+      )
+    end
+  end
+end

--- a/spec/blueprints/child_blueprint_spec.rb
+++ b/spec/blueprints/child_blueprint_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ChildBlueprint do
+  let(:child) { create(:child) }
+  let(:blueprint) { ChildBlueprint.render(child) }
+  context 'returns the correct fields when no view option is passed' do
+    it 'only includes the ID' do
+      expect(JSON.parse(blueprint).keys).to contain_exactly('id')
+    end
+  end
+  context 'returns the correct fields when IL view is requested' do
+    let(:blueprint) { ChildBlueprint.render(child, view: :illinois_dashboard) }
+    it 'includes IL dashboard fields' do
+      expect(JSON.parse(blueprint).keys).to contain_exactly(
+        'attendance_rate',
+        'attendance_risk',
+        'case_number',
+        'full_name',
+        'guaranteed_revenue',
+        'max_approved_revenue',
+        'potential_revenue'
+      )
+    end
+  end
+  context 'returns the correct fields when NE view is requested' do
+    let(:blueprint) { ChildBlueprint.render(child, view: :nebraska_dashboard) }
+    it 'includes the child name and all cases' do
+      expect(JSON.parse(blueprint).keys).to contain_exactly(
+        'absences',
+        'attendance_risk',
+        'case_number',
+        'earned_revenue',
+        'estimated_revenue',
+        'full_days',
+        'full_name',
+        'hours',
+        'transportation_revenue'
+      )
+    end
+  end
+end

--- a/spec/blueprints/user_blueprint_spec.rb
+++ b/spec/blueprints/user_blueprint_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserBlueprint do
+  let(:user) { create(:user) }
+  let(:blueprint) { UserBlueprint.render(user) }
+  context 'returns the correct fields when no view option is passed' do
+    it 'only includes the ID' do
+      expect(JSON.parse(blueprint).keys).to contain_exactly(
+        'greeting_name',
+        'id',
+        'language',
+        'state'
+      )
+    end
+  end
+  context 'returns the correct fields when IL view is requested' do
+    let(:blueprint) { UserBlueprint.render(user, view: :illinois_dashboard) }
+    it 'includes IL dashboard fields' do
+      expect(JSON.parse(blueprint).keys).to contain_exactly(
+        'as_of',
+        'businesses',
+        'first_approval_effective_date'
+      )
+    end
+  end
+  context 'returns the correct fields when NE view is requested' do
+    let(:blueprint) { UserBlueprint.render(user, view: :nebraska_dashboard) }
+    it 'includes the user name and all cases' do
+      expect(JSON.parse(blueprint).keys).to contain_exactly(
+        'as_of',
+        'first_approval_effective_date',
+        'businesses',
+        'max_revenue',
+        'total_approved'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Adds specs for blueprints and guard clauses for fields when no filter date is passed in

# 💅🏼 What issue does this fix?
N/A - spec coverage for existing behavior

## 🧳 Steps to test
The dashboard should still display correctly