### PR TITLE
927/fix dashboard header issues on small devices

### DIFF
--- a/client/src/Dashboard/DashboardTitle.js
+++ b/client/src/Dashboard/DashboardTitle.js
@@ -13,7 +13,6 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
   // const [isDropdownVisible, setDropdownVisible] = useState(false)
   // const dropdownStyle = { color: '#006C9E' }
   const [dateFilterValue, setDateFilterValue] = useState(dates.dateFilterValue)
-  const [isSmallDevice, setIsSmallDevice] = useState(false)
 
   const matchAndReplaceDate = (dateString = '') => {
     const match = dateString.match(/^[A-Za-z]+/)
@@ -26,35 +25,10 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
     }
   }, [dates, dateFilterValue])
 
-  useEffect(() => {
-    const mediaQueryList = window.matchMedia('(max-width: 560px)')
-    // addEventListener is unavailable for media query lists in Safari 13 or below
-    const isSafari13 = typeof mediaQueryList.addEventListener !== 'function'
-    const handleWidthChange = evt => setIsSmallDevice(evt.matches)
-
-    handleWidthChange(mediaQueryList)
-
-    if (isSafari13) {
-      mediaQueryList.addListener(handleWidthChange)
-    } else {
-      mediaQueryList.addEventListener('change', handleWidthChange)
-    }
-
-    return () => {
-      if (isSafari13) {
-        mediaQueryList.removeListener(handleWidthChange)
-      } else {
-        mediaQueryList.removeEventListener('change', handleWidthChange)
-      }
-    }
-  }, [])
-
   return (
     <div className="dashboard-title m-2">
-      <div className={`flex items-center mb-3 ${isSmallDevice && 'flex-col'}`}>
-        <Typography.Title
-          className={`dashboard-title mr-4 ${isSmallDevice && 'text-center'}`}
-        >
+      <div className="flex flex-col items-center mb-3 sm:flex-row">
+        <Typography.Title className="dashboard-title mr-4 text-center">
           {t('dashboardTitle')}
         </Typography.Title>
         {userState !== 'NE' ? (
@@ -89,7 +63,7 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
             {matchAndReplaceDate(dates?.dateFilterValue?.displayDate ?? '')}
           </Button>
         ) : null}
-        <Typography.Text className={`text-gray3 ${isSmallDevice && 'mt-1'}`}>
+        <Typography.Text className={'text-gray3 mt-1 sm:mt-0'}>
           {`${t(`asOf`)}: ${matchAndReplaceDate(dates.asOf)}`}
         </Typography.Text>
       </div>

--- a/client/src/Dashboard/DashboardTitle.js
+++ b/client/src/Dashboard/DashboardTitle.js
@@ -63,7 +63,7 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
             {matchAndReplaceDate(dates?.dateFilterValue?.displayDate ?? '')}
           </Button>
         ) : null}
-        <Typography.Text className={'text-gray3 mt-1 sm:mt-0'}>
+        <Typography.Text className="text-gray3 mt-1 sm:mt-0">
           {`${t(`asOf`)}: ${matchAndReplaceDate(dates.asOf)}`}
         </Typography.Text>
       </div>

--- a/client/src/Dashboard/DashboardTitle.js
+++ b/client/src/Dashboard/DashboardTitle.js
@@ -27,8 +27,8 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
 
   return (
     <div className="dashboard-title m-2">
-      <div className="flex flex-col items-center mb-3 sm:flex-row">
-        <Typography.Title className="dashboard-title mr-4 text-center">
+      <div className="flex flex-col items-center mb-4 sm:mb-3 sm:flex-row">
+        <Typography.Title className="dashboard-title text-center sm:mr-4">
           {t('dashboardTitle')}
         </Typography.Title>
         {userState !== 'NE' ? (
@@ -47,7 +47,7 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
               setDateFilterValue(value)
             }}
             size="large"
-            className="date-filter-select mr-2 text-base"
+            className="date-filter-select my-2 text-base sm:mr-2 "
           >
             {(dates?.dateFilterMonths ?? []).map((month, k) => (
               <Option key={k} value={month.date}>
@@ -63,7 +63,7 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
             {matchAndReplaceDate(dates?.dateFilterValue?.displayDate ?? '')}
           </Button>
         ) : null}
-        <Typography.Text className="text-gray3 mt-1 sm:mt-0">
+        <Typography.Text className="text-gray3">
           {`${t(`asOf`)}: ${matchAndReplaceDate(dates.asOf)}`}
         </Typography.Text>
       </div>

--- a/client/src/Dashboard/DashboardTitle.js
+++ b/client/src/Dashboard/DashboardTitle.js
@@ -13,6 +13,7 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
   // const [isDropdownVisible, setDropdownVisible] = useState(false)
   // const dropdownStyle = { color: '#006C9E' }
   const [dateFilterValue, setDateFilterValue] = useState(dates.dateFilterValue)
+  const [isSmallDevice, setIsSmallDevice] = useState(false)
 
   const matchAndReplaceDate = (dateString = '') => {
     const match = dateString.match(/^[A-Za-z]+/)
@@ -25,10 +26,35 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
     }
   }, [dates, dateFilterValue])
 
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia('(max-width: 560px)')
+    // addEventListener is unavailable for media query lists in Safari 13 or below
+    const isSafari13 = typeof mediaQueryList.addEventListener !== 'function'
+    const handleWidthChange = evt => setIsSmallDevice(evt.matches)
+
+    handleWidthChange(mediaQueryList)
+
+    if (isSafari13) {
+      mediaQueryList.addListener(handleWidthChange)
+    } else {
+      mediaQueryList.addEventListener('change', handleWidthChange)
+    }
+
+    return () => {
+      if (isSafari13) {
+        mediaQueryList.removeListener(handleWidthChange)
+      } else {
+        mediaQueryList.removeEventListener('change', handleWidthChange)
+      }
+    }
+  }, [])
+
   return (
     <div className="dashboard-title m-2">
-      <div className="flex items-center mb-3">
-        <Typography.Title className="dashboard-title mr-4">
+      <div className={`flex items-center mb-3 ${isSmallDevice && 'flex-col'}`}>
+        <Typography.Title
+          className={`dashboard-title mr-4 ${isSmallDevice && 'text-center'}`}
+        >
           {t('dashboardTitle')}
         </Typography.Title>
         {userState !== 'NE' ? (
@@ -63,7 +89,7 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
             {matchAndReplaceDate(dates?.dateFilterValue?.displayDate ?? '')}
           </Button>
         ) : null}
-        <Typography.Text className="text-gray3">
+        <Typography.Text className={`text-gray3 ${isSmallDevice && 'mt-1'}`}>
           {`${t(`asOf`)}: ${matchAndReplaceDate(dates.asOf)}`}
         </Typography.Text>
       </div>


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  DO NOT use "Fixes #123" or anything that will auto-close the ticket, we want the ticket open until it's QAed. -->
#927 "As of date" falls off screen in XS size on NE dashboard

It now looks like this on smaller devices:
<img width="377" alt="small-device" src="https://user-images.githubusercontent.com/13953987/112913819-61d5a500-90af-11eb-84eb-7b9dac38cf83.png">

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [x] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?
