### PR TITLE
Remove 'of XX' from full days and hours columns

### DIFF
--- a/client/src/Dashboard/DashboardTable.js
+++ b/client/src/Dashboard/DashboardTable.js
@@ -54,7 +54,7 @@ export default function DashboardTable({ tableData, userState, setActiveKey }) {
     const renderCell = (color, text) => {
       return (
         <div className="-mb-4">
-          <p className="mb-1">{fullday.text.replace('of', t('of'))}</p>
+          <p className="mb-1">{fullday.text.split(' ')[0]}</p>
           <Tag className={`${color}-tag custom-tag`}>{t(text)}</Tag>
         </div>
       )
@@ -194,7 +194,7 @@ export default function DashboardTable({ tableData, userState, setActiveKey }) {
             name: 'hours',
             sorter: (a, b) =>
               a.hours.match(/^\d+/)[0] - b.hours.match(/^\d+/)[0],
-            render: text => replaceText(text, 'of')
+            render: text => text.split(' ')[0]
           },
           {
             name: 'absences',


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  DO NOT use "Fixes #123" or anything that will auto-close the ticket, we want the ticket open until it's QAed. -->
#1150

<img width="801" alt="dash-2" src="https://user-images.githubusercontent.com/13953987/114632379-73a07600-9c73-11eb-8a20-c08d9069e9ab.png">

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [x] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [x] Did you run `yarn lint` in `/client`?
* [x] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?


