### PR TITLE
Adds family_in_home to license types and buffs up the specs

### DIFF
--- a/app/models/concerns/licenses.rb
+++ b/app/models/concerns/licenses.rb
@@ -12,6 +12,7 @@ module Licenses
     license_exempt_center
     family_child_care_home_i
     family_child_care_home_ii
+    family_in_home
   ].freeze
 
   included do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_21_155206) do
+ActiveRecord::Schema.define(version: 2021_06_04_184925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2021_05_21_155206) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "child_approval_id", null: false
     t.string "wonderschool_id"
+    t.string "absence"
     t.index ["child_approval_id"], name: "index_attendances_on_child_approval_id"
   end
 
@@ -133,7 +134,7 @@ ActiveRecord::Schema.define(version: 2021_05_21_155206) do
     t.datetime "updated_at", precision: 6, null: false
     t.decimal "attendance_threshold"
     t.string "county", default: " ", null: false
-    t.date "effective_on", default: "2021-05-21", null: false
+    t.date "effective_on", default: "2021-06-12", null: false
     t.date "expires_on"
     t.string "license_type", default: "licensed_family_home", null: false
     t.decimal "max_age", default: "0.0", null: false

--- a/spec/models/business_spec.rb
+++ b/spec/models/business_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Business, type: :model do
   it { should belong_to(:user) }
   it { should validate_presence_of(:name) }
 
+  it_behaves_like 'licenses'
+
   it 'validates uniqueness of business name' do
     create(:business)
     should validate_uniqueness_of(:name).scoped_to(:user_id)

--- a/spec/models/illinois_rate_spec.rb
+++ b/spec/models/illinois_rate_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe IllinoisRate, type: :model do
   it { should validate_numericality_of(:part_day_rate) }
   it { should validate_numericality_of(:silver_percentage) }
 
+  it_behaves_like 'licenses'
+
   let(:illinois_rate) { build(:illinois_rate) }
 
   it 'validates effective_on as a date' do

--- a/spec/support/api/schemas/license_types.json
+++ b/spec/support/api/schemas/license_types.json
@@ -6,7 +6,10 @@
       "licensed_family_home",
       "licensed_group_home",
       "license_exempt_home",
-      "license_exempt_center"
+      "license_exempt_center",
+      "family_child_care_home_i",
+      "family_child_care_home_ii",
+      "family_in_home"
     ]
   }
 }

--- a/spec/support/licenses_shared_examples.rb
+++ b/spec/support/licenses_shared_examples.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples 'licenses' do
+  let(:model) { described_class } # the class that includes the concern
+
+  it 'validates the license type against the list' do
+    license_object = FactoryBot.build(model.to_s.underscore.to_sym, license_type: 'family_in_home')
+    expect(license_object).to be_valid
+    license_object.license_type = 'fake license name'
+    expect(license_object).not_to be_valid
+  end
+end


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
#1271 - adds family_in_home to license types and buffs up the specs

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write tests?
* [X] Did you run `bundle exec rspec` from the root?
* [X] Did you run `bundle exec rails rswag` from the root?
* [X] Did you run `bundle exec rubocop` from the root?

## 🧳 Steps to test
Go to rails console and create a Business with a license_type of `family_in_home` - it should work.  Try to add a Business with a license_type of "fake type" - it should not work.