### PR TITLE
[PIE-1332] Adds a GET endpoint for attendances

### DIFF
--- a/app/controllers/api/v1/attendances_controller.rb
+++ b/app/controllers/api/v1/attendances_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # API for user attendances
+    class AttendancesController < Api::V1::ApiController
+      # GET /attendances
+      def index
+        @attendances = policy_scope(Attendance).for_week(filter_date)
+
+        render json: AttendanceBlueprint.render(@attendances)
+      end
+
+      private
+
+      def filter_date
+        params[:filter_date] ? Time.zone.parse(params[:filter_date]) : nil
+      end
+    end
+  end
+end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -20,7 +20,14 @@ class Attendance < UuidApplicationRecord
 
   validates :absence, inclusion: { in: ABSENCE_TYPES }, allow_nil: true
 
-  scope :for_month, ->(month = Time.current) { where('check_in BETWEEN ? AND ?', month.at_beginning_of_month, month.at_end_of_month) }
+  scope :for_month, lambda { |month = nil|
+    month ||= Time.current
+    where('check_in BETWEEN ? AND ?', month.at_beginning_of_month, month.at_end_of_month)
+  }
+  scope :for_week, lambda { |week = nil|
+    week ||= Time.current
+    where('check_in BETWEEN ? AND ?', week.at_beginning_of_week, week.at_end_of_week)
+  }
 
   scope :illinois_part_days, -> { where('total_time_in_care < ?', '5 hours') }
   scope :illinois_full_days, -> { where('total_time_in_care BETWEEN ? AND ?', '5 hours', '12 hours') }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
       get 'profile', to: 'users#show'
       resources :businesses
       resources :children
+      resources :attendances, only: :index
       resources :attendance_batches, only: :create
       get 'case_list_for_dashboard', to: 'users#case_list_for_dashboard'
     end

--- a/spec/factories/attendances.rb
+++ b/spec/factories/attendances.rb
@@ -8,7 +8,8 @@ FactoryBot.define do
       Faker::Time.between(from: Time.current.at_beginning_of_month, to: Time.current)
     end
     check_out { check_in + rand(0..23).hours + rand(0..59).minutes }
-    absence { Attendance::ABSENCE_TYPES.sample }
+
+    absence { Random.rand(10) > 7 ? nil : Attendance::ABSENCE_TYPES.sample }
 
     factory :illinois_part_day_attendance do
       check_in do

--- a/spec/models/attendance_spec.rb
+++ b/spec/models/attendance_spec.rb
@@ -70,6 +70,25 @@ RSpec.describe Attendance, type: :model do
     end
   end
 
+  context 'for_week scope' do
+    let(:child) { create(:child) }
+    let(:timezone) { ActiveSupport::TimeZone.new(child.timezone) }
+    let(:child_approval) { child.child_approvals.first }
+    let(:current_attendance) { create(:attendance, check_in: Faker::Time.between(from: Time.current.at_beginning_of_week, to: Time.current), child_approval: child_approval) }
+    let(:past_attendance) do
+      create(:attendance, child_approval: child_approval, check_in: Time.new(2020, 12, 1, 9, 31, 0, timezone),
+                          check_out: Time.new(2020, 12, 1, 16, 56, 0, timezone))
+    end
+    it 'returns attendances for given weeks' do
+      date = Time.new(2020, 12, 4, 0, 0, 0, timezone).to_date
+      expect(Attendance.for_week).to include(current_attendance)
+      expect(Attendance.for_week).not_to include(past_attendance)
+      expect(Attendance.for_week(date)).to include(past_attendance)
+      expect(Attendance.for_week(date)).not_to include(current_attendance)
+      expect(Attendance.for_week(date - 1.week).size).to eq(0)
+    end
+  end
+
   context 'illinois day length scopes' do
     let(:child) { create(:child, business: create(:business, zipcode: '60606')) }
     let(:timezone) { ActiveSupport::TimeZone.new(child.timezone) }

--- a/spec/requests/api/v1/attendance_batches_spec.rb
+++ b/spec/requests/api/v1/attendance_batches_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe 'Api::V1::AttendanceBatches', type: :request do
     include_context 'correct api version header'
 
     before do
-      logged_in_user = create(:confirmed_user)
       sign_in logged_in_user
     end
 

--- a/spec/requests/api/v1/attendances_spec.rb
+++ b/spec/requests/api/v1/attendances_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Api::V1::Attendances', type: :request do
+  let!(:logged_in_user) { create(:confirmed_user) }
+  let!(:business) { create(:business, user: logged_in_user) }
+  let!(:child) { create(:child, business: business) }
+  let!(:this_week_attendances) do
+    create_list(:attendance, 3, child_approval: child.child_approvals.first, check_in: Faker::Time.between(from: Time.current.at_beginning_of_week, to: Time.current))
+  end
+  let!(:past_attendances) do
+    create_list(:attendance, 2, child_approval: child.child_approvals.first,
+                                check_in: Faker::Time.between(from: (Time.current - 2.weeks).at_beginning_of_week, to: (Time.current - 2.weeks).at_end_of_week))
+  end
+  let!(:extra_attendances) { create_list(:attendance, 3, check_in: Faker::Time.between(from: Time.current.at_beginning_of_week, to: Time.current)) }
+
+  describe 'GET /api/v1/attendances' do
+    include_context 'correct api version header'
+
+    before do
+      sign_in logged_in_user
+    end
+
+    context 'when sent with a filter date' do
+      let(:params) { { filter_date: Time.zone.today - 2.weeks } }
+      it 'displays the attendances' do
+        get '/api/v1/attendances', params: params, headers: headers
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response.collect { |x| x['child_approval_id'] }).to match_array(past_attendances.collect(&:child_approval_id))
+        expect(parsed_response.collect { |x| x['total_time_in_care'] }).to match_array(past_attendances.collect { |x| x.total_time_in_care.to_s })
+        expect(parsed_response.length).to eq(2)
+        expect(response).to match_response_schema('attendances')
+      end
+    end
+
+    context 'when sent without a filter date' do
+      it 'displays the attendances' do
+        get '/api/v1/attendances', params: {}, headers: headers
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response.collect { |x| x['child_approval_id'] }).to match_array(this_week_attendances.collect(&:child_approval_id))
+        expect(parsed_response.collect { |x| x['total_time_in_care'] }).to match_array(this_week_attendances.collect { |x| x.total_time_in_care.to_s })
+        expect(parsed_response.length).to eq(3)
+        expect(response).to match_response_schema('attendances')
+      end
+    end
+
+    context 'when viewed by an admin' do
+      before do
+        admin = create(:admin)
+        sign_in admin
+      end
+      it 'displays the attendances' do
+        get '/api/v1/attendances', params: {}, headers: headers
+        parsed_response = JSON.parse(response.body)
+        all_current_attendances = this_week_attendances + extra_attendances
+        expect(parsed_response.collect { |x| x['child_approval_id'] }).to match_array(all_current_attendances.collect(&:child_approval_id))
+        expect(parsed_response.collect { |x| x['total_time_in_care'] }).to match_array(all_current_attendances.collect { |x| x.total_time_in_care.to_s })
+        expect(parsed_response.length).to eq(6)
+        expect(response).to match_response_schema('attendances')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a GET endpoint for attendances, added a weekly scope to default the initial call to

# 💅🏼 What issue does this fix?
#1332 - unblocks the attendance view

## 🍂 Before You Submit
* [X] Did you write tests?
* [X] Did you run `bundle exec rspec` from the root?
* [X] Did you run `bundle exec rails rswag` from the root?
* [X] Did you run `bundle exec rubocop` from the root?

## 🧳 Steps to test
open up a Rails console:
```
$ bundle exec rails console
> require 'factory_bot_rails'
=> false
> FactoryBot.create_list(:attendance, 3, check_in: Faker::Time.between(from: Time.current.at_beginning_of_week, to: Time.current))
```
This will create three attendances this week.  In Postman, log in as an admin, and hit `/api/v1/attendances` with no filter_date.  You should see all 3 attendances you created.

If you want to test specific users' views, you can do this:
```
$ bundle exec rails console
> require 'factory_bot_rails'
=> false
> child = FactoryBot.create(:child, business: Business.find_by(user: User.find_by(email: "test@test.com")))
> FactoryBot.create_list(:attendance, 3, child_approval: child.active_child_approval(Time.current), check_in: Faker::Time.between(from: Time.current.at_beginning_of_week, to: now))
```
Then log in as that user and make sure you don't see all; log in as an admin and make sure you do see all six.