### PR TITLE
[PIE-698] Adds full_day calculations for Nebraska, based on feature flag

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,13 +9,14 @@ DEVISE_JWT_SECRET_KEY=[generate by running `rails secret`]
 ############
 
 # FF_LIVE_ALGORITHMS_HOURS=[true/false]
+# FF_LIVE_ALGORITHMS_FULL_DAYS=[true/false]
 
 ############
 # optional
 ############
 
-# to allow seeded records and attendances
-# ALLOW_SEEDING=true
+# to allow seeded records and attendances - best to have this on in development environment
+ALLOW_SEEDING=true
 
 # If your postgres 12.3 server is running on a port different from 5432
 # DB_PORT=5431 

--- a/app/blueprints/child_blueprint.rb
+++ b/app/blueprints/child_blueprint.rb
@@ -49,8 +49,9 @@ class ChildBlueprint < Blueprinter::Base
     field :estimated_revenue do |child|
       child.temporary_nebraska_dashboard_case&.estimated_revenue&.to_f || 0.0
     end
-    field :full_days do |child|
-      child.temporary_nebraska_dashboard_case&.full_days
+    field :full_days do |child, options|
+      # Uses a feature flag in the child model methods
+      child.nebraska_full_days(options[:filter_date])&.to_s
     end
     field :full_name
     field :hours do |child, options|

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -70,8 +70,12 @@ class Child < UuidApplicationRecord
   # NE dashboard hours calculator
   def nebraska_hours(filter_date)
     # "feature flag" for using live algorithms rather than uploaded data
-    ff_live_algorithms_hours = Rails.application.config.respond_to?(:ff_live_algorithms_hours) ? Rails.application.config.ff_live_algorithms_hours == 'true' : false
-    ff_live_algorithms_hours ? NebraskaHoursCalculator.new(self, filter_date).call : temporary_nebraska_dashboard_case&.hours.to_f
+    Rails.application.config.ff_live_algorithms_hours ? NebraskaHoursCalculator.new(self, filter_date).call : temporary_nebraska_dashboard_case&.hours.to_f
+  end
+
+  # NE dashboard full days calculator
+  def nebraska_full_days(filter_date)
+    Rails.application.config.ff_live_algorithms_full_days ? NebraskaFullDaysCalculator.new(self, filter_date).call : temporary_nebraska_dashboard_case&.full_days
   end
 
   private

--- a/app/services/nebraska_full_days_calculator.rb
+++ b/app/services/nebraska_full_days_calculator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Service to calculate full days used in Nebraska by specific kids
+class NebraskaFullDaysCalculator
+  def initialize(child, filter_date)
+    @child = child
+    @filter_date = filter_date
+  end
+
+  def call
+    calculate_full_days
+  end
+
+  private
+
+  def calculate_full_days
+    @child.attendances.for_month(@filter_date).reduce(0) do |sum, attendance|
+      sum + calculate_full_days_based_on_duration(attendance.total_time_in_care)
+    end
+  end
+
+  def calculate_full_days_based_on_duration(duration)
+    if duration > (5.hours + 45.minutes)
+      1
+    else
+      0
+    end
+  end
+end

--- a/app/services/nebraska_hours_calculator.rb
+++ b/app/services/nebraska_hours_calculator.rb
@@ -20,13 +20,13 @@ class NebraskaHoursCalculator
   end
 
   def round_hourly_to_quarters(duration)
-    adjusted_duration = if duration < (5.hours + 45.minutes)
+    adjusted_duration = if duration <= (5.hours + 45.minutes)
                           duration
-                        elsif duration > 10.hours && duration < (14.hours + 45.minutes)
+                        elsif duration > 10.hours && duration <= (14.hours + 45.minutes)
                           duration - 10.hours
                         else
                           0.minutes
                         end
-    (adjusted_duration.in_minutes / 60 * 4).round / 4.0
+    (adjusted_duration.in_minutes / 15.0).ceil * 15 / 60.0
   end
 end

--- a/app/services/nebraska_hours_calculator.rb
+++ b/app/services/nebraska_hours_calculator.rb
@@ -20,13 +20,18 @@ class NebraskaHoursCalculator
   end
 
   def round_hourly_to_quarters(duration)
-    adjusted_duration = if duration <= (5.hours + 45.minutes)
-                          duration
-                        elsif duration > 10.hours && duration <= (14.hours + 45.minutes)
-                          duration - 10.hours
-                        else
-                          0.minutes
-                        end
-    (adjusted_duration.in_minutes / 15.0).ceil * 15 / 60.0
+    (adjusted_duration(duration).in_minutes / 15.0).ceil * 15 / 60.0
+  end
+
+  def adjusted_duration(duration)
+    if duration <= (5.hours + 45.minutes)
+      duration
+    elsif duration > 10.hours && duration <= 18.hours
+      duration - 10.hours
+    elsif duration > 18.hours
+      8.hours
+    else
+      0.minutes
+    end
   end
 end

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "antd-mask-input": "^0.1.15",
     "craco-less": "^1.18.0",
     "csv": "^5.5.0",
-    "dayjs": "^1.10.5",
+    "dayjs": "^1.10.6",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.4.0",
     "hash-anything": "^1.3.2",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4410,10 +4410,10 @@ date-fns@^2.15.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.21.3.tgz#8f5f6889d7a96bbcc1f0ea50239b397a83357f9b"
   integrity sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==
 
-dayjs@^1.10.5:
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.5.tgz#5600df4548fc2453b3f163ebb2abbe965ccfb986"
-  integrity sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g==
+dayjs@^1.10.6:
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.6.tgz#288b2aa82f2d8418a6c9d4df5898c0737ad02a63"
+  integrity sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,7 +66,8 @@ module App
     config.aws_necc_dashboard_archive_bucket = ENV.fetch('AWS_NECC_DASHBOARD_ARCHIVE_BUCKET', '')
     config.aws_necc_onboarding_bucket = ENV.fetch('AWS_NECC_ONBOARDING_BUCKET', '')
     config.aws_necc_onboarding_archive_bucket = ENV.fetch('AWS_NECC_ONBOARDING_ARCHIVE_BUCKET', '')
-    config.ff_live_algorithms_hours = ENV.fetch('FF_LIVE_ALGORITHMS_HOURS', '')
+    config.ff_live_algorithms_hours = ENV.fetch('FF_LIVE_ALGORITHMS_HOURS', '') == 'true'
+    config.ff_live_algorithms_full_days = ENV.fetch('FF_LIVE_ALGORITHMS_FULL_DAYS', '') == 'true'
     config.sendmail_username = ENV.fetch('SENDMAIL_USERNAME', '')
   end
 end

--- a/lib/tasks/test698.rake
+++ b/lib/tasks/test698.rake
@@ -19,9 +19,9 @@ namespace :test698 do
         active_child_approval = child.active_child_approval(Time.current)
         next unless child && active_child_approval
 
-        puts "\n\n\n\nChild: #{child.full_name} should have: #{child.schedules.empty? ? 'no hours' : 'an entry for the number of hours in their schedule (7)'}\n\n\n\n"
+        puts "\n\n\n\nChild: #{child.full_name} should have an entry for the number of days in their schedule (1)'}\n\n\n\n"
 
-        Attendance.create!(child_approval: active_child_approval, check_in: DateTime.new(2021, 6, 3, 7, 0, 0), check_out: nil)
+        Attendance.create!(child_approval: active_child_approval, check_in: DateTime.new(2021, 7, 3, 7, 0, 0), check_out: nil)
       end
 
     else

--- a/lib/tasks/test698.rake
+++ b/lib/tasks/test698.rake
@@ -21,7 +21,7 @@ namespace :test698 do
 
         puts "\n\n\n\nChild: #{child.full_name} should have an entry for the number of days in their schedule (1)'}\n\n\n\n"
 
-        Attendance.create!(child_approval: active_child_approval, check_in: DateTime.new(2021, 7, 3, 7, 0, 0), check_out: nil)
+        Attendance.create!(child_approval: active_child_approval, check_in: DateTime.new(2021, 7, 5, 7, 0, 0), check_out: nil)
       end
 
     else

--- a/lib/tasks/test698.rake
+++ b/lib/tasks/test698.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+namespace :test698 do
+  task kids_and_schedules: :environment do
+    if Rails.application.config.allow_seeding
+      children = Child.joins(:business).where(business: { state: 'NE' }).take(2)
+      return unless children
+
+      children.map do |child|
+        child.update(active: true)
+        child.schedules.destroy_all
+        child.attendances.destroy_all
+      end
+
+      Schedule.create!(child: children.first, weekday: 1, start_time: '8:00AM', end_time: '3:00PM', effective_on: 'June 1, 2021')
+
+      children.map do |child|
+        child.reload
+        active_child_approval = child.active_child_approval(Time.current)
+        next unless child && active_child_approval
+
+        puts "\n\n\n\nChild: #{child.full_name} should have: #{child.schedules.empty? ? 'no hours' : 'an entry for the number of hours in their schedule (7)'}\n\n\n\n"
+
+        Attendance.create!(child_approval: active_child_approval, check_in: DateTime.new(2021, 6, 3, 7, 0, 0), check_out: nil)
+      end
+
+    else
+      puts 'Error seeding attendances: this environment does not allow for seeding attendances'
+    end
+  end
+end

--- a/lib/tasks/test714.rake
+++ b/lib/tasks/test714.rake
@@ -26,7 +26,7 @@ namespace :test714 do
         child.attendances.destroy_all
       end
 
-      Schedule.create!(child: children.first, weekday: 4, start_time: '8:00AM', end_time: '12:00PM', effective_on: 'May 1, 2021')
+      Schedule.create!(child: children.first, weekday: 1, start_time: '8:00AM', end_time: '12:00PM', effective_on: 'June 1, 2021')
 
       children.map do |child|
         child.reload
@@ -35,7 +35,7 @@ namespace :test714 do
 
         puts "\n\n\n\nChild: #{child.full_name} should have: #{child.schedules.empty? ? 'no hours' : 'an entry for the number of hours in their schedule (4)'}\n\n\n\n"
 
-        Attendance.create!(child_approval: active_child_approval, check_in: DateTime.new(2021, 7, 1, 7, 0, 0), check_out: nil)
+        Attendance.create!(child_approval: active_child_approval, check_in: DateTime.new(2021, 6, 3, 7, 0, 0), check_out: nil)
       end
 
     else

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "cypress": "^7.6.0",
     "cypress-file-upload": "^5.0.8",
-    "dayjs": "^1.10.5",
+    "dayjs": "^1.10.6",
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-cypress": "^2.11.3",

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -99,12 +99,32 @@ RSpec.describe Child, type: :model do
     end
   end
 
+  describe '#nebraska_full_days' do
+    context 'using live algorithms' do
+      it 'calls the NebraskaFullDaysCalculator service' do
+        calculator_instance = instance_double(NebraskaFullDaysCalculator)
+
+        allow(Rails.application.config).to receive(:ff_live_algorithms_full_days).and_return(true)
+        expect(NebraskaFullDaysCalculator).to receive(:new).with(child, Time.current.to_date).and_return(calculator_instance)
+        expect(calculator_instance).to receive(:call)
+        child.nebraska_full_days(Time.current.to_date)
+      end
+    end
+    context 'using temporary dashboard values' do
+      it 'does not call the NebraskaFullDaysCalculator service' do
+        allow(Rails.application.config).to receive(:ff_live_algorithms_full_days).and_return(false)
+        expect(NebraskaFullDaysCalculator).not_to receive(:new)
+        child.nebraska_full_days(Time.current.to_date)
+      end
+    end
+  end
+
   describe '#nebraska_hours' do
     context 'using live algorithms' do
       it 'calls the NebraskaHoursCalculator service' do
         calculator_instance = instance_double(NebraskaHoursCalculator)
 
-        allow(Rails.application.config).to receive(:ff_live_algorithms_hours).and_return('true')
+        allow(Rails.application.config).to receive(:ff_live_algorithms_hours).and_return(true)
         expect(NebraskaHoursCalculator).to receive(:new).with(child, Time.current.to_date).and_return(calculator_instance)
         expect(calculator_instance).to receive(:call)
         child.nebraska_hours(Time.current.to_date)
@@ -112,7 +132,7 @@ RSpec.describe Child, type: :model do
     end
     context 'using temporary dashboard values' do
       it 'does not call the NebraskaHoursCalculator service' do
-        allow(Rails.application.config).to receive(:ff_live_algorithms_hours).and_return('false')
+        allow(Rails.application.config).to receive(:ff_live_algorithms_hours).and_return(false)
         expect(NebraskaHoursCalculator).not_to receive(:new)
         child.nebraska_hours(Time.current.to_date)
       end

--- a/spec/services/nebraska_full_days_calculator_spec.rb
+++ b/spec/services/nebraska_full_days_calculator_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NebraskaFullDaysCalculator, type: :service do
+  let!(:child) { create(:necc_child) }
+  let!(:child_approval) { child.child_approvals.first }
+  let(:first_attendance_date) { child_approval.approval.effective_on.at_end_of_month + 2.days }
+  let(:second_attendance_date) { child_approval.approval.effective_on.at_end_of_month + 4.days }
+
+  describe '#call' do
+    context 'the child has an attendance with no checkout' do
+      it 'determines full days attended from the schedule' do
+        child.schedules.destroy_all
+        child.schedules << create(:schedule,
+                                  effective_on: first_attendance_date - 3.months,
+                                  weekday: first_attendance_date.wday,
+                                  start_time: first_attendance_date.to_datetime + 8.hours,
+                                  end_time: first_attendance_date.to_datetime + 15.hours)
+        create(:attendance, child_approval: child_approval, check_in: first_attendance_date.to_datetime + 8.hours + 21.minutes, check_out: nil)
+        expect(described_class.new(child, first_attendance_date).call).to eq(1)
+      end
+      it 'defaults to 8 hours, which will count as full day units, if they have no schedule' do
+        child.schedules.destroy_all
+        create(:attendance, child_approval: child_approval, check_in: first_attendance_date.to_datetime + 8.hours, check_out: nil)
+        expect(described_class.new(child, first_attendance_date).call).to eq(1)
+      end
+    end
+    context 'the child has an attendance less than or equal to 6 hours' do
+      it 'will not count as a full day' do
+        check_in = first_attendance_date.to_datetime + 8.hours
+        check_out = check_in + 5.hours + 10.minutes
+        create(:attendance, child_approval: child_approval, check_in: check_in, check_out: check_out)
+        expect(described_class.new(child, first_attendance_date).call).to eq(0)
+      end
+    end
+    context 'the child has an attendance more than 6 hours but less than 10 hours' do
+      it 'counts as a full day' do
+        check_in = first_attendance_date.to_datetime + 8.hours
+        check_out = check_in + 6.hours + 10.minutes
+        create(:attendance, child_approval: child_approval, check_in: check_in, check_out: check_out)
+        expect(described_class.new(child, first_attendance_date).call).to eq(1)
+      end
+    end
+    context 'the child has an attendance more than 10 hours but less than or equal to 18 hours' do
+      it 'counts as a full day + hours (handled by the other calculator)' do
+        check_in = first_attendance_date.to_datetime + 8.hours
+        check_out = check_in + 13.hours + 40.minutes
+        create(:attendance, child_approval: child_approval, check_in: check_in, check_out: check_out)
+        expect(described_class.new(child, first_attendance_date).call).to eq(1)
+      end
+    end
+    context 'the child has multiple attendances' do
+      context 'one counts for full day units and the other does not' do
+        it 'only returns the full day units for the correct attendance' do
+          first_check_in = first_attendance_date.to_datetime + 8.hours
+          first_check_out = first_check_in + 5.hours + 10.minutes
+          second_check_in = second_attendance_date.to_datetime + 8.hours
+          second_check_out = second_check_in + 7.hours
+          create(:attendance, child_approval: child_approval, check_in: first_check_in, check_out: first_check_out)
+          create(:attendance, child_approval: child_approval, check_in: second_check_in, check_out: second_check_out)
+          expect(described_class.new(child, first_attendance_date).call).to eq(1)
+        end
+      end
+      context 'neither count for full day units' do
+        it 'returns 0' do
+          first_check_in = first_attendance_date.to_datetime + 8.hours
+          first_check_out = first_check_in + 4.hours
+          second_check_in = second_attendance_date.to_datetime + 8.hours
+          second_check_out = second_check_in + 3.hours
+          create(:attendance, child_approval: child_approval, check_in: first_check_in, check_out: first_check_out)
+          create(:attendance, child_approval: child_approval, check_in: second_check_in, check_out: second_check_out)
+          expect(described_class.new(child, first_attendance_date).call).to eq(0)
+        end
+      end
+      context 'both count for full day units' do
+        it 'sums them' do
+          first_check_in = first_attendance_date.to_datetime + 8.hours
+          first_check_out = first_check_in + 8.hours + 10.minutes
+          second_check_in = second_attendance_date.to_datetime + 8.hours
+          second_check_out = second_check_in + 6.hours + 22.minutes
+          create(:attendance, child_approval: child_approval, check_in: first_check_in, check_out: first_check_out)
+          create(:attendance, child_approval: child_approval, check_in: second_check_in, check_out: second_check_out)
+          expect(described_class.new(child, first_attendance_date).call).to eq(2)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/nebraska_hours_calculator_spec.rb
+++ b/spec/services/nebraska_hours_calculator_spec.rb
@@ -56,17 +56,19 @@ RSpec.describe NebraskaHoursCalculator, type: :service do
           first_check_in = first_attendance_date.to_datetime + 8.hours
           first_check_out = first_check_in + 5.hours + 10.minutes
           second_check_in = second_attendance_date.to_datetime + 8.hours
+          second_check_out = second_check_in + 8.hours
           create(:attendance, child_approval: child_approval, check_in: first_check_in, check_out: first_check_out)
-          create(:attendance, child_approval: child_approval, check_in: second_check_in, check_out: nil)
+          create(:attendance, child_approval: child_approval, check_in: second_check_in, check_out: second_check_out)
           expect(described_class.new(child, first_attendance_date).call).to eq(5.25)
         end
       end
       context 'neither count for hourly units' do
         it 'returns 0' do
           first_check_in = first_attendance_date.to_datetime + 8.hours
+          first_check_out = first_check_in + 8.hours
           second_check_in = second_attendance_date.to_datetime + 8.hours
           second_check_out = second_check_in + 8.hours
-          create(:attendance, child_approval: child_approval, check_in: first_check_in, check_out: nil)
+          create(:attendance, child_approval: child_approval, check_in: first_check_in, check_out: first_check_out)
           create(:attendance, child_approval: child_approval, check_in: second_check_in, check_out: second_check_out)
           expect(described_class.new(child, first_attendance_date).call).to eq(0)
         end
@@ -79,7 +81,7 @@ RSpec.describe NebraskaHoursCalculator, type: :service do
           second_check_out = second_check_in + 10.hours + 22.minutes
           create(:attendance, child_approval: child_approval, check_in: first_check_in, check_out: first_check_out)
           create(:attendance, child_approval: child_approval, check_in: second_check_in, check_out: second_check_out)
-          expect(described_class.new(child, first_attendance_date).call).to eq(5.25 + 0.25)
+          expect(described_class.new(child, first_attendance_date).call).to eq(5.25 + 0.5)
         end
       end
     end

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,10 +494,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-dayjs@^1.10.4, dayjs@^1.10.5:
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.5.tgz#5600df4548fc2453b3f163ebb2abbe965ccfb986"
-  integrity sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g==
+dayjs@^1.10.4, dayjs@^1.10.6:
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.6.tgz#288b2aa82f2d8418a6c9d4df5898c0737ad02a63"
+  integrity sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==
 
 debug@4.3.2, debug@^4.0.1, debug@^4.1.1, debug@^4.3.2:
   version "4.3.2"


### PR DESCRIPTION
# 💅🏼 What issue does this fix?
closes #698 - this creates a Nebraska Full Days calculator based on the P4P Nebraska Model and the calculations being done in the prediction algorithm spreadsheet.  It assumes that any attendance greater than or equal to 5 hours and 45 minutes counts as a full day, unless it is greater than or equal to 14 hours and 45 minutes, at which point it becomes two full days

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write tests?
* [x] Did you run `bundle exec rspec` from the root?
* [x] Did you run `bundle exec rails rswag` from the root?
* [x] Did you run `bundle exec rubocop` from the root?

## 🧳 Steps to test
There's a convenient rake task you can run using `bundle exec rails test698:kids_and_schedules` which will populate one of the NE kids with a schedule of 7 hours, and one without a schedule at all, and give them each an Attendance with a nil `check_out` time.  The date used in the rake task is June 3rd, 2021; if QA happens in July, I'll change the date before we get there.  Both kids should have 1 full day in their June dashboard when viewed after running this task, with the live algorithms environment variable set to `true` - set the following in your `.env`: `FF_LIVE_ALGORITHMS=true`

## 🕯 Caveats, concerns
Make sure to look at the tests and verify we're testing the most important behavior.
