### PR TITLE
Removes extra step from E2E process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,10 +159,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: Build frontend
-        run: |
-          yarn
-          yarn heroku-postbuild
       - name: Run Cypress tests
         run: yarn cy:ci
         env:


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

No ticket - just needed to rectify a double-build on the E2E test step

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?
* [ ] Did you run `yarn lint` in `/client`?
* [ ] Did you run `yarn test` in `/client`?
* [ ] Are your primary keys UUIDs on any new tables?

## 🏺 Accessibility
<!-- Did you find any accessibility issues in your UI components?  Did you mitigate them?  If not, link the bug tickets you filed for mitigation. -->

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Data Migrations
* [ ] Schema Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
