### PR TITLE
[PIE-1385] Adds validation to attendance to make sure check_out is after check_in

### DIFF
--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -12,6 +12,7 @@ class Attendance < UuidApplicationRecord
 
   validates :check_in, time_param: true, presence: true
   validates :check_out, time_param: true, unless: proc { |attendance| attendance.check_out_before_type_cast.nil? }
+  validate :check_out_after_check_in
 
   ABSENCE_TYPES = %w[
     absence
@@ -52,6 +53,12 @@ class Attendance < UuidApplicationRecord
 
   def child_schedule
     child_approval.child.schedules.active_on_date(check_in.to_date).for_weekday(check_in.wday).first
+  end
+
+  def check_out_after_check_in
+    return if check_out.blank? || check_in.blank?
+
+    errors.add(:check_out, 'must be after the check in time') if check_out < check_in
   end
 end
 

--- a/spec/models/attendance_spec.rb
+++ b/spec/models/attendance_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Attendance, type: :model do
 
   it { should validate_presence_of(:check_in) }
 
-  let(:attendance) { build(:attendance) }
+  let(:attendance) { build(:attendance, check_out: nil) }
   it 'validates check_in as a Time' do
     attendance.update(check_in: Time.zone.now)
     expect(attendance.valid?).to be_truthy
@@ -15,7 +15,7 @@ RSpec.describe Attendance, type: :model do
     expect(attendance.valid?).to be_falsey
     attendance.check_in = nil
     expect(attendance.valid?).to be_falsey
-    attendance.check_in = '2021-02-01 11pm'
+    attendance.check_in = Time.zone.now.strftime('%Y-%m-%d %I:%M%P')
     expect(attendance.valid?).to be_truthy
     attendance.check_in = Date.new(2021, 12, 11)
     expect(attendance.valid?).to be_truthy
@@ -28,7 +28,7 @@ RSpec.describe Attendance, type: :model do
     expect(attendance.valid?).to be_falsey
     attendance.check_out = nil
     expect(attendance.valid?).to be_truthy
-    attendance.check_out = '2021-02-01 11pm'
+    attendance.check_out = Time.zone.now.strftime('%Y-%m-%d %I:%M%P')
     expect(attendance.valid?).to be_truthy
     attendance.check_out = Date.new(2021, 12, 11)
     expect(attendance.valid?).to be_truthy
@@ -45,6 +45,15 @@ RSpec.describe Attendance, type: :model do
     expect(attendance).not_to be_valid
     expect(attendance.errors.messages.keys).to eq([:absence])
     expect(attendance.errors.messages[:absence]).to include('is not included in the list')
+  end
+
+  it 'validates that the check_out is after the check_in if it is present' do
+    attendance.update(check_out: Time.current - 90.years)
+    expect(attendance.errors.messages[:check_out]).to be_present
+    attendance.update(check_out: Time.current + 3.days)
+    expect(attendance.errors.messages[:check_out]).not_to be_present
+    attendance.update(check_out: nil)
+    expect(attendance.errors.messages[:check_out]).not_to be_present
   end
 
   it 'factory should be valid (default; no args)' do


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Fixes #1385 by adding a validation to the attendance model to make sure check_out > check_in

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write tests?
* [ ] Did you run `bundle exec rspec` from the root?
* [ ] Did you run `bundle exec rails rswag` from the root?
* [ ] Did you run `bundle exec rubocop` from the root?

## 🧳 Steps to test
Run the attendance_batches endpoint and try and add an attendance with a check_out time before the check_in time.  You should get an error.