### PR TITLE
Updates the as_of in the user blueprint to use the user's current timzone

### DIFF
--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -12,7 +12,7 @@ class UserBlueprint < Blueprinter::Base
   view :illinois_dashboard do
     field(:as_of) do |user, options|
       # if there are no attendances, the rates are as of today
-      (user.latest_attendance_in_month(options[:filter_date]) || Time.current).strftime('%m/%d/%Y')
+      (user.latest_attendance_in_month(options[:filter_date])&.in_time_zone(user.timezone) || Time.current.in_time_zone(user.timezone)).strftime('%m/%d/%Y')
     end
     field(:first_approval_effective_date) do |user, _options|
       user.first_approval_effective_date
@@ -24,7 +24,7 @@ class UserBlueprint < Blueprinter::Base
   view :nebraska_dashboard do
     field(:as_of) do |user, options|
       # if there are no attendances, the rates are as of today
-      (user.latest_attendance_in_month(options[:filter_date]) || Time.current).strftime('%m/%d/%Y')
+      (user.latest_attendance_in_month(options[:filter_date])&.in_time_zone(user.timezone) || Time.current.in_time_zone(user.timezone)).strftime('%m/%d/%Y')
     end
     field(:first_approval_effective_date) do |user, _options|
       user.first_approval_effective_date

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,10 +46,8 @@ class User < UuidApplicationRecord
 
   def latest_attendance_in_month(filter_date)
     filter_date ||= Time.current
-    # TODO: Fix this query using joins to eager load the child approvals and businesses
-    Attendance.where('check_in BETWEEN ? AND ?', filter_date.at_beginning_of_month, filter_date.at_end_of_month)
-              .where(child_approval: ChildApproval.where(child: Child.where(business: Business.where(user: self))))
-              .max_by(&:check_in)&.check_in
+    attendances.where('check_in BETWEEN ? AND ?', filter_date.in_time_zone(timezone).at_beginning_of_month,
+                      filter_date.in_time_zone(timezone).at_end_of_month).max_by(&:check_in)&.check_in
   end
 
   def first_approval_effective_date

--- a/spec/blueprints/user_blueprint_spec.rb
+++ b/spec/blueprints/user_blueprint_spec.rb
@@ -37,4 +37,34 @@ RSpec.describe UserBlueprint do
       )
     end
   end
+  context 'returns the correct as of date' do
+    let(:last_month) { Time.now.in_time_zone(user.timezone).at_beginning_of_day - 1.month }
+    before do
+      create(:attendance, check_in: last_month, child_approval: create(:child_approval, child: create(:child, business: create(:business, user: user))))
+    end
+    context 'in nebraska' do
+      it "returns the as_of date in the user's timezone" do
+        travel_to Time.now.in_time_zone(user.timezone).at_end_of_day
+        blueprint = UserBlueprint.render(user, view: :nebraska_dashboard)
+        expect(JSON.parse(blueprint)['as_of']).to eq(Time.now.in_time_zone(user.timezone).strftime('%m/%d/%Y'))
+      end
+      it 'returns the as_of date for the last attendance in the prior month' do
+        attendance = create(:attendance, check_in: last_month)
+        blueprint = UserBlueprint.render(user, view: :nebraska_dashboard, filter_date: last_month.at_end_of_month)
+        expect(JSON.parse(blueprint)['as_of']).to eq(attendance.check_in.strftime('%m/%d/%Y'))
+      end
+    end
+    context 'in illinois' do
+      it "returns the as_of date in the user's timezone" do
+        travel_to Time.now.in_time_zone(user.timezone).at_end_of_day
+        blueprint = UserBlueprint.render(user, view: :illinois_dashboard)
+        expect(JSON.parse(blueprint)['as_of']).to eq(Time.now.in_time_zone(user.timezone).strftime('%m/%d/%Y'))
+      end
+      it 'returns the as_of date for the last attendance in the prior month' do
+        attendance = create(:attendance, check_in: last_month)
+        blueprint = UserBlueprint.render(user, view: :illinois_dashboard, filter_date: last_month.at_end_of_month)
+        expect(JSON.parse(blueprint)['as_of']).to eq(attendance.check_in.strftime('%m/%d/%Y'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Updates the as_of in the user blueprint to use the user's current timezone, and also simplifies the latest_attendance_in_month logic

## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Fixes #1429 

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write tests?
* [X] Did you run `bundle exec rspec` from the root?
* [X] Did you run `bundle exec rubocop` from the root?

## 🧳 Steps to test
This is really only testable in the evening after UTC has rolled to tomorrow, so sometime in the evening CST someone should log into staging and make sure "as_of" says today :)