### PR TITLE
[PIE-1038] Updates the family fee to read dynamically from the db

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,9 +8,7 @@ DEVISE_JWT_SECRET_KEY=[generate by running `rails secret`]
 # feature flags
 ############
 
-# FF_LIVE_ALGORITHMS_HOURS=[true/false]
-# FF_LIVE_ALGORITHMS_FULL_DAYS=[true/false]
-# FF_LIVE_ALGORITHMS_WEEKLY_HOURS_ATTENDED=[true/false]
+# FF_NE_LIVE_ALGORITHMS=[true/false]
 
 ############
 # optional

--- a/app/blueprints/child_blueprint.rb
+++ b/app/blueprints/child_blueprint.rb
@@ -40,8 +40,8 @@ class ChildBlueprint < Blueprinter::Base
     field :case_number do |child, options|
       child.approvals.active_on_date(options[:filter_date]).first&.case_number
     end
-    field :family_fee do |child|
-      child.temporary_nebraska_dashboard_case&.family_fee&.to_f || 0.0
+    field :family_fee do |child, options|
+      child.nebraska_family_fee(options[:filter_date])
     end
     field :earned_revenue do |child|
       child.temporary_nebraska_dashboard_case&.earned_revenue&.to_f || 0.0

--- a/app/models/child_approval.rb
+++ b/app/models/child_approval.rb
@@ -5,9 +5,9 @@ class ChildApproval < UuidApplicationRecord
   belongs_to :child
   belongs_to :approval
   belongs_to :illinois_rate, optional: true
-  has_many :illinois_approval_amounts, dependent: :restrict_with_error
-  has_many :nebraska_approval_amounts, dependent: :restrict_with_error
-  has_many :attendances, dependent: :restrict_with_error
+  has_many :illinois_approval_amounts, dependent: :destroy
+  has_many :nebraska_approval_amounts, dependent: :destroy
+  has_many :attendances, dependent: :destroy
 
   delegate :user, to: :child
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,9 +66,7 @@ module App
     config.aws_necc_dashboard_archive_bucket = ENV.fetch('AWS_NECC_DASHBOARD_ARCHIVE_BUCKET', '')
     config.aws_necc_onboarding_bucket = ENV.fetch('AWS_NECC_ONBOARDING_BUCKET', '')
     config.aws_necc_onboarding_archive_bucket = ENV.fetch('AWS_NECC_ONBOARDING_ARCHIVE_BUCKET', '')
-    config.ff_live_algorithms_hours = ENV.fetch('FF_LIVE_ALGORITHMS_HOURS', '') == 'true'
-    config.ff_live_algorithms_full_days = ENV.fetch('FF_LIVE_ALGORITHMS_FULL_DAYS', '') == 'true'
-    config.ff_live_algorithms_weekly_hours_attended = ENV.fetch('FF_LIVE_ALGORITHMS_WEEKLY_HOURS_ATTENDED', '') == 'true'
+    config.ff_ne_live_algorithms = ENV.fetch('FF_NE_LIVE_ALGORITHMS', '') == 'true'
     config.sendmail_username = ENV.fetch('SENDMAIL_USERNAME', '')
     config.wonderschool_attendance_url = ENV.fetch('WONDERSCHOOL_ATTENDANCE_URL', '')
   end

--- a/spec/factories/children.rb
+++ b/spec/factories/children.rb
@@ -20,10 +20,21 @@ FactoryBot.define do
     end
 
     factory :necc_child do
+      transient do
+        effective_date { Time.zone.today - 6.months }
+        create_dashboard_case { false }
+      end
+
       business { create(:business, :nebraska) }
       wonderschool_id { SecureRandom.uuid }
-      after(:create) do |child|
+      approvals { [create(:approval, effective_on: effective_date, create_children: false)] }
+
+      after(:create) do |child, evaluator|
         create(:schedule, child: child)
+        create(:temporary_nebraska_dashboard_case, child: child) if evaluator.create_dashboard_case
+        create(:nebraska_approval_amount,
+               child_approval: child.active_child_approval(evaluator.effective_date),
+               effective_on: evaluator.effective_date - 2.months)
       end
     end
 

--- a/spec/factories/nebraska_approval_amounts.rb
+++ b/spec/factories/nebraska_approval_amounts.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :nebraska_approval_amount do
+    allocated_family_fee { Faker::Number.decimal(l_digits: 2) }
+    effective_on { (Time.current - 9.months).to_date }
+    expires_on { effective_on + 1.year }
+    family_fee { Faker::Number.decimal(l_digits: 2) }
+    child_approval
+  end
+end

--- a/spec/models/child_approval_spec.rb
+++ b/spec/models/child_approval_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe ChildApproval, type: :model do
   it { should belong_to(:child) }
   it { should belong_to(:approval) }
   it { should belong_to(:illinois_rate).optional }
-  it { should have_many(:illinois_approval_amounts).dependent(:restrict_with_error) }
-  it { should have_many(:attendances).dependent(:restrict_with_error) }
+  it { should have_many(:illinois_approval_amounts).dependent(:destroy) }
+  it { should have_many(:nebraska_approval_amounts).dependent(:destroy) }
+  it { should have_many(:attendances).dependent(:destroy) }
   it 'factory should be valid (default; no args)' do
     expect(build(:child_approval)).to be_valid
   end

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -99,66 +99,83 @@ RSpec.describe Child, type: :model do
     end
   end
 
-  describe '#nebraska_full_days' do
-    context 'using live algorithms' do
-      it 'calls the NebraskaFullDaysCalculator service' do
-        calculator_instance = instance_double(NebraskaFullDaysCalculator)
-
-        allow(Rails.application.config).to receive(:ff_live_algorithms_full_days).and_return(true)
-        expect(NebraskaFullDaysCalculator).to receive(:new).with(child, Time.current.to_date).and_return(calculator_instance)
-        expect(calculator_instance).to receive(:call)
-        child.nebraska_full_days(Time.current.to_date)
+  context 'for nebraska children' do
+    let(:child) { create(:necc_child, create_dashboard_case: true) }
+    describe '#nebraska_family_fee' do
+      context 'using live algorithms' do
+        it 'returns the database value' do
+          allow(Rails.application.config).to receive(:ff_ne_live_algorithms).and_return(true)
+          expect(child.nebraska_family_fee(Time.current.to_date)).to eq(format('%.2f', child.active_nebraska_approval_amount(Time.current.to_date).family_fee))
+        end
+      end
+      context 'using temporary dashboard values' do
+        it 'does not call the NebraskaFullDaysCalculator service' do
+          allow(Rails.application.config).to receive(:ff_ne_live_algorithms).and_return(false)
+          expect(child.nebraska_family_fee(Time.current.to_date)).to eq(format('%.2f', child.temporary_nebraska_dashboard_case.family_fee))
+        end
       end
     end
-    context 'using temporary dashboard values' do
-      it 'does not call the NebraskaFullDaysCalculator service' do
-        allow(Rails.application.config).to receive(:ff_live_algorithms_full_days).and_return(false)
-        expect(NebraskaFullDaysCalculator).not_to receive(:new)
-        child.nebraska_full_days(Time.current.to_date)
+
+    describe '#nebraska_full_days' do
+      context 'using live algorithms' do
+        it 'calls the NebraskaFullDaysCalculator service' do
+          calculator_instance = instance_double(NebraskaFullDaysCalculator)
+
+          allow(Rails.application.config).to receive(:ff_ne_live_algorithms).and_return(true)
+          expect(NebraskaFullDaysCalculator).to receive(:new).with(child, Time.current.to_date).and_return(calculator_instance)
+          expect(calculator_instance).to receive(:call)
+          child.nebraska_full_days(Time.current.to_date)
+        end
+      end
+      context 'using temporary dashboard values' do
+        it 'does not call the NebraskaFullDaysCalculator service' do
+          allow(Rails.application.config).to receive(:ff_ne_live_algorithms).and_return(false)
+          expect(NebraskaFullDaysCalculator).not_to receive(:new)
+          child.nebraska_full_days(Time.current.to_date)
+        end
+      end
+    end
+
+    describe '#nebraska_hours' do
+      context 'using live algorithms' do
+        it 'calls the NebraskaHoursCalculator service' do
+          calculator_instance = instance_double(NebraskaHoursCalculator)
+
+          allow(Rails.application.config).to receive(:ff_ne_live_algorithms).and_return(true)
+          expect(NebraskaHoursCalculator).to receive(:new).with(child, Time.current.to_date).and_return(calculator_instance)
+          expect(calculator_instance).to receive(:call)
+          child.nebraska_hours(Time.current.to_date)
+        end
+      end
+      context 'using temporary dashboard values' do
+        it 'does not call the NebraskaHoursCalculator service' do
+          allow(Rails.application.config).to receive(:ff_ne_live_algorithms).and_return(false)
+          expect(NebraskaHoursCalculator).not_to receive(:new)
+          child.nebraska_hours(Time.current.to_date)
+        end
+      end
+    end
+
+    describe '#nebraska_weekly_hours_attended' do
+      context 'using live algorithms' do
+        it 'calls the NebraskaWeeklyHoursAttendedCalculator service' do
+          calculator_instance = instance_double(NebraskaWeeklyHoursAttendedCalculator)
+
+          allow(Rails.application.config).to receive(:ff_ne_live_algorithms).and_return(true)
+          expect(NebraskaWeeklyHoursAttendedCalculator).to receive(:new).with(child, Time.current.to_date).and_return(calculator_instance)
+          expect(calculator_instance).to receive(:call)
+          child.nebraska_weekly_hours_attended(Time.current.to_date)
+        end
+      end
+      context 'using temporary dashboard values' do
+        it 'does not call the NebraskaWeeklyHoursAttendedCalculator service' do
+          allow(Rails.application.config).to receive(:ff_ne_live_algorithms).and_return(false)
+          expect(NebraskaWeeklyHoursAttendedCalculator).not_to receive(:new)
+          child.nebraska_weekly_hours_attended(Time.current.to_date)
+        end
       end
     end
   end
-
-  describe '#nebraska_hours' do
-    context 'using live algorithms' do
-      it 'calls the NebraskaHoursCalculator service' do
-        calculator_instance = instance_double(NebraskaHoursCalculator)
-
-        allow(Rails.application.config).to receive(:ff_live_algorithms_hours).and_return(true)
-        expect(NebraskaHoursCalculator).to receive(:new).with(child, Time.current.to_date).and_return(calculator_instance)
-        expect(calculator_instance).to receive(:call)
-        child.nebraska_hours(Time.current.to_date)
-      end
-    end
-    context 'using temporary dashboard values' do
-      it 'does not call the NebraskaHoursCalculator service' do
-        allow(Rails.application.config).to receive(:ff_live_algorithms_hours).and_return(false)
-        expect(NebraskaHoursCalculator).not_to receive(:new)
-        child.nebraska_hours(Time.current.to_date)
-      end
-    end
-  end
-
-  describe '#nebraska_weekly_hours_attended' do
-    context 'using live algorithms' do
-      it 'calls the NebraskaWeeklyHoursAttendedCalculator service' do
-        calculator_instance = instance_double(NebraskaWeeklyHoursAttendedCalculator)
-
-        allow(Rails.application.config).to receive(:ff_live_algorithms_weekly_hours_attended).and_return(true)
-        expect(NebraskaWeeklyHoursAttendedCalculator).to receive(:new).with(child, Time.current.to_date).and_return(calculator_instance)
-        expect(calculator_instance).to receive(:call)
-        child.nebraska_weekly_hours_attended(Time.current.to_date)
-      end
-    end
-    context 'using temporary dashboard values' do
-      it 'does not call the NebraskaWeeklyHoursAttendedCalculator service' do
-        allow(Rails.application.config).to receive(:ff_live_algorithms_weekly_hours_attended).and_return(false)
-        expect(NebraskaWeeklyHoursAttendedCalculator).not_to receive(:new)
-        child.nebraska_weekly_hours_attended(Time.current.to_date)
-      end
-    end
-  end
-
   context 'approval methods' do
     it 'returns an active approval for a specific date' do
       current_approval = child.approvals.first

--- a/spec/models/nebraska_approval_amount.rb
+++ b/spec/models/nebraska_approval_amount.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NebraskaApprovalAmount, type: :model do
+  it { should belong_to(:child_approval) }
+
+  it 'factory should be valid (default; no args)' do
+    expect(build(:nebraska_approval_amount)).to be_valid
+  end
+end


### PR DESCRIPTION
Updates the family fee to read dynamically from the db when the feature flag is flipped; moves all dashboard fields to a single ff again

## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Fixes #1038 


## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write tests?
* [X] Did you run `bundle exec rspec` from the root?
* [X] Did you run `bundle exec rubocop` from the root?

## 🧵 Steps to set up locally

Change your env var to true for the feature flag (note we've reduced it down to one env var)

## 🧳 Steps to test
- flip the flag to "false" and restart the server
- create a temporary dashboard case for a nebraska child from the console
- visit the dashboard, you should see your family fee value
- create a nebraska_approval_amount with an effective date before today for the child's active child approval, with a *different* family fee amount
- flip the flag to "true" and restart the server
- you should see the family fee value from the approval amount instead of the dashboard case