### PR TITLE
Ensures consistent use of Time.current, sets timezone in specs to UTC

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,9 +40,9 @@ class ApplicationController < ActionController::API
   end
 
   def collect_metrics
-    start = Time.zone.now
+    start = Time.current
     yield
-    duration = Time.zone.now - start
+    duration = Time.current - start
     Rails.logger.info "#{controller_name}##{action_name}: #{duration}s"
   end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,4 +48,7 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  # CI environment runs on UTC so this should help us catch and reproduce timezone errors locally
+  config.time_zone = 'UTC'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,8 +18,8 @@ APR_1 = Date.new(THIS_YEAR, 4, 1)
 JUN_30 = Date.new(THIS_YEAR, 6, 30)
 
 # minimum birthdates (ages)
-MIN_BIRTHDAY = (Time.zone.now - 2.weeks)
-MAX_BIRTHDAY = (Time.zone.now - 14.years)
+MIN_BIRTHDAY = (Time.current - 2.weeks)
+MAX_BIRTHDAY = (Time.current - 14.years)
 
 # Use puts to show the number of records in the database for a given class
 def puts_records_in_db(klass)

--- a/spec/blueprints/child_blueprint_spec.rb
+++ b/spec/blueprints/child_blueprint_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe ChildBlueprint do
       end
       let(:family_fee) { child.active_nebraska_approval_amount(attendance_date).family_fee }
       it 'includes the child name and all live attendance data' do
-        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.zone.now))
+        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.current))
         # 3 hours of attendance from the hourly attendance created above on the 8th
         expect(parsed_body['hours']).to eq('3.0')
         # 1 full day of attendance from the daily attendance created above on the 8th
@@ -108,9 +108,9 @@ RSpec.describe ChildBlueprint do
         # too early in the month to show risk
         expect(parsed_body['attendance_risk']).to eq('not_enough_info')
 
-        travel_to Time.zone.now + 11.days # second dashboard view date is Jul 22nd, 2021 at 4pm
+        travel_to Time.current + 11.days # second dashboard view date is Jul 22nd, 2021 at 4pm
 
-        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.zone.now))
+        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.current))
         # no new hourly attendance
         expect(parsed_body['hours']).to eq('3.0')
         # no new daily attendance
@@ -131,7 +131,7 @@ RSpec.describe ChildBlueprint do
           check_out: attendance_date.to_datetime + 9.days + 6.hours + 15.minutes
         )
 
-        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.zone.now))
+        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.current))
         # one new hourly attendance
         expect(parsed_body['hours']).to eq('6.25')
         # no new daily attendance
@@ -152,7 +152,7 @@ RSpec.describe ChildBlueprint do
           check_out: attendance_date.to_datetime + 8.days + 9.hours + 18.minutes
         )
 
-        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.zone.now))
+        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.current))
         # no new hourly attendance
         expect(parsed_body['hours']).to eq('6.25')
         # one new daily attendance
@@ -180,7 +180,7 @@ RSpec.describe ChildBlueprint do
           check_in: attendance_date.to_datetime + 8.days + 3.hours, absence: 'absence'
         )
 
-        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.zone.now))
+        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.current))
         # 5 new daily attendance
         expect(parsed_body['full_days']).to eq('7.0')
         # 3 new absences
@@ -200,7 +200,7 @@ RSpec.describe ChildBlueprint do
           absence: 'absence'
         )
 
-        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.zone.now))
+        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.current))
         # no new daily attendance
         expect(parsed_body['full_days']).to eq('7.0')
         # 3 new absences
@@ -219,7 +219,7 @@ RSpec.describe ChildBlueprint do
           absence: 'covid_absence'
         )
 
-        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.zone.now))
+        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.current))
         # 1 new covid absence
         expect(parsed_body['absences']).to eq('7 of 5')
         # This includes the 7 prior dailies, the 5 prior absences, and this absence because COVID absences are unlimited at this time
@@ -232,11 +232,11 @@ RSpec.describe ChildBlueprint do
         create(
           :attendance,
           child_approval: child_approval,
-          check_in: Time.zone.now - 7.hours,
-          check_out: Time.zone.now - 10.minutes
+          check_in: Time.current - 7.hours,
+          check_out: Time.current - 10.minutes
         )
 
-        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.zone.now))
+        parsed_body = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.current))
         # 1 new daily attendance
         expect(parsed_body['full_days']).to eq('8.0')
         # This includes the 7 prior dailies, the 6 prior absences, and a new full-day attendance today
@@ -275,8 +275,8 @@ RSpec.describe ChildBlueprint do
         child.reload
         child_with_less_hours.reload
 
-        child_json = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.zone.now))
-        child_with_less_hours_json = JSON.parse(described_class.render(child_with_less_hours, view: :nebraska_dashboard, filter_date: Time.zone.now))
+        child_json = JSON.parse(described_class.render(child, view: :nebraska_dashboard, filter_date: Time.current))
+        child_with_less_hours_json = JSON.parse(described_class.render(child_with_less_hours, view: :nebraska_dashboard, filter_date: Time.current))
 
         expect(child_json['family_fee']).to eq(format('%.2f', family_fee))
         expect(child_with_less_hours_json['family_fee']).to eq(format('%.2f', 0))

--- a/spec/blueprints/user_blueprint_spec.rb
+++ b/spec/blueprints/user_blueprint_spec.rb
@@ -69,15 +69,16 @@ RSpec.describe UserBlueprint do
   end
 
   context 'returns the correct as of date' do
-    let(:last_month) { Time.now.in_time_zone(user.timezone).at_beginning_of_day - 1.month }
+    let(:last_month) { Time.current.at_beginning_of_day - 1.month }
     before do
       create(:attendance, check_in: last_month, child_approval: create(:child_approval, child: create(:child, business: create(:business, user: user))))
     end
     context 'in nebraska' do
       it "returns the as_of date in the user's timezone" do
-        travel_to Time.now.in_time_zone(user.timezone).at_end_of_day
+        travel_to Time.current.at_end_of_day
+
         blueprint = UserBlueprint.render(user, view: :nebraska_dashboard)
-        expect(JSON.parse(blueprint)['as_of']).to eq(Time.now.in_time_zone(user.timezone).strftime('%m/%d/%Y'))
+        expect(JSON.parse(blueprint)['as_of']).to eq(Time.current.strftime('%m/%d/%Y'))
         travel_back
       end
       it 'returns the as_of date for the last attendance in the prior month' do
@@ -87,14 +88,14 @@ RSpec.describe UserBlueprint do
       end
       it 'returns the as_of date as today for a month with no attendances' do
         blueprint = UserBlueprint.render(user, view: :nebraska_dashboard, filter_date: last_month.at_end_of_month - 6.months)
-        expect(JSON.parse(blueprint)['as_of']).to eq(Time.now.in_time_zone(user.timezone).strftime('%m/%d/%Y'))
+        expect(JSON.parse(blueprint)['as_of']).to eq(Time.current.strftime('%m/%d/%Y'))
       end
     end
     context 'in illinois' do
       it "returns the as_of date in the user's timezone" do
-        travel_to Time.now.in_time_zone(user.timezone).at_end_of_day
+        travel_to Time.current.at_end_of_day
         blueprint = UserBlueprint.render(user, view: :illinois_dashboard)
-        expect(JSON.parse(blueprint)['as_of']).to eq(Time.now.in_time_zone(user.timezone).strftime('%m/%d/%Y'))
+        expect(JSON.parse(blueprint)['as_of']).to eq(Time.current.strftime('%m/%d/%Y'))
         travel_back
       end
       it 'returns the as_of date for the last attendance in the prior month' do
@@ -104,7 +105,7 @@ RSpec.describe UserBlueprint do
       end
       it 'returns the as_of date as today for a month with no attendances' do
         blueprint = UserBlueprint.render(user, view: :nebraska_dashboard, filter_date: last_month.at_end_of_month - 6.months)
-        expect(JSON.parse(blueprint)['as_of']).to eq(Time.now.in_time_zone(user.timezone).strftime('%m/%d/%Y'))
+        expect(JSON.parse(blueprint)['as_of']).to eq(Time.current.strftime('%m/%d/%Y'))
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
       before(:create) do |user|
         user.skip_confirmation!
       end
-      confirmed_at { Time.zone.at(rand * Time.now.to_i) }
+      confirmed_at { Time.zone.at(rand * Time.current.to_i) }
     end
 
     factory :unconfirmed_user do
@@ -35,7 +35,7 @@ FactoryBot.define do
       before(:create) do |user|
         user.skip_confirmation!
       end
-      confirmed_at { Time.zone.at(rand * Time.now.to_i) }
+      confirmed_at { Time.zone.at(rand * Time.current.to_i) }
       admin { true }
     end
   end

--- a/spec/models/approval_spec.rb
+++ b/spec/models/approval_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Approval, type: :model do
   let(:effective_date) { (Time.current - 6.months).to_date }
 
   it 'validates effective_on as a date' do
-    approval.update(effective_on: Time.zone.now)
+    approval.update(effective_on: Time.current)
     expect(approval.valid?).to be_truthy
     approval.effective_on = "I'm a string"
     expect(approval.valid?).to be_falsey
@@ -24,7 +24,7 @@ RSpec.describe Approval, type: :model do
   end
 
   it 'validates expires_on as an optional date' do
-    approval.update(expires_on: Time.zone.now)
+    approval.update(expires_on: Time.current)
     expect(approval.valid?).to be_truthy
     approval.expires_on = "I'm a string"
     expect(approval.valid?).to be_falsey

--- a/spec/models/attendance_spec.rb
+++ b/spec/models/attendance_spec.rb
@@ -9,26 +9,26 @@ RSpec.describe Attendance, type: :model do
 
   let(:attendance) { build(:attendance, check_out: nil) }
   it 'validates check_in as a Time' do
-    attendance.update(check_in: Time.zone.now)
+    attendance.update(check_in: Time.current)
     expect(attendance.valid?).to be_truthy
     attendance.check_in = "I'm a string"
     expect(attendance.valid?).to be_falsey
     attendance.check_in = nil
     expect(attendance.valid?).to be_falsey
-    attendance.check_in = Time.zone.now.strftime('%Y-%m-%d %I:%M%P')
+    attendance.check_in = Time.current.strftime('%Y-%m-%d %I:%M%P')
     expect(attendance.valid?).to be_truthy
     attendance.check_in = Date.new(2021, 12, 11)
     expect(attendance.valid?).to be_truthy
   end
 
   it 'validates check_out as an optional Time' do
-    attendance.update(check_out: Time.zone.now)
+    attendance.update(check_out: Time.current)
     expect(attendance.valid?).to be_truthy
     attendance.check_out = "I'm a string"
     expect(attendance.valid?).to be_falsey
     attendance.check_out = nil
     expect(attendance.valid?).to be_truthy
-    attendance.check_out = Time.zone.now.strftime('%Y-%m-%d %I:%M%P')
+    attendance.check_out = Time.current.strftime('%Y-%m-%d %I:%M%P')
     expect(attendance.valid?).to be_truthy
     attendance.check_out = Date.new(2021, 12, 11)
     expect(attendance.valid?).to be_truthy

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Child, type: :model do
   it { should validate_presence_of(:full_name) }
 
   it 'validates date_of_birth as a date' do
-    child.update(date_of_birth: Time.zone.now)
+    child.update(date_of_birth: Time.current)
     expect(child.valid?).to be_truthy
     child.date_of_birth = "I'm a string"
     expect(child.valid?).to be_falsey
@@ -28,7 +28,7 @@ RSpec.describe Child, type: :model do
   end
 
   it 'validates last_active_date as an optional date' do
-    child.update(last_active_date: Time.zone.now)
+    child.update(last_active_date: Time.current)
     expect(child.valid?).to be_truthy
     child.last_active_date = "I'm a string"
     expect(child.valid?).to be_falsey

--- a/spec/models/illinois_rate_spec.rb
+++ b/spec/models/illinois_rate_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe IllinoisRate, type: :model do
   let(:illinois_rate) { build(:illinois_rate) }
 
   it 'validates effective_on as a date' do
-    illinois_rate.update(effective_on: Time.zone.now)
+    illinois_rate.update(effective_on: Time.current)
     expect(illinois_rate.valid?).to be_truthy
     illinois_rate.effective_on = "I'm a string"
     expect(illinois_rate.valid?).to be_falsey
@@ -34,7 +34,7 @@ RSpec.describe IllinoisRate, type: :model do
   end
 
   it 'validates expires_on as an optional date' do
-    illinois_rate.update(expires_on: Time.zone.now)
+    illinois_rate.update(expires_on: Time.current)
     expect(illinois_rate.valid?).to be_truthy
     illinois_rate.expires_on = "I'm a string"
     expect(illinois_rate.valid?).to be_falsey

--- a/spec/models/nebraska_rate_spec.rb
+++ b/spec/models/nebraska_rate_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe NebraskaRate, type: :model do
   let(:nebraska_rate) { build(:nebraska_rate) }
 
   it 'validates effective_on as a date' do
-    nebraska_rate.update(effective_on: Time.zone.now)
+    nebraska_rate.update(effective_on: Time.current)
     expect(nebraska_rate.valid?).to be_truthy
     nebraska_rate.effective_on = "I'm a string"
     expect(nebraska_rate.valid?).to be_falsey
@@ -30,7 +30,7 @@ RSpec.describe NebraskaRate, type: :model do
   end
 
   it 'validates expires_on as an optional date' do
-    nebraska_rate.update(expires_on: Time.zone.now)
+    nebraska_rate.update(expires_on: Time.current)
     expect(nebraska_rate.valid?).to be_truthy
     nebraska_rate.expires_on = "I'm a string"
     expect(nebraska_rate.valid?).to be_falsey

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Schedule, type: :model do
   let(:schedule) { build(:schedule) }
 
   it 'validates effective_on as a date' do
-    schedule.update(effective_on: Time.zone.now)
+    schedule.update(effective_on: Time.current)
     expect(schedule.valid?).to be_truthy
     schedule.effective_on = "I'm a string"
     expect(schedule.valid?).to be_falsey
@@ -26,7 +26,7 @@ RSpec.describe Schedule, type: :model do
   end
 
   it 'validates expires_on as an optional date' do
-    schedule.update(expires_on: Time.zone.now)
+    schedule.update(expires_on: Time.current)
     expect(schedule.valid?).to be_truthy
     schedule.expires_on = "I'm a string"
     expect(schedule.valid?).to be_falsey
@@ -39,7 +39,7 @@ RSpec.describe Schedule, type: :model do
   end
 
   it 'validates start_time as a time' do
-    schedule.update(start_time: Time.zone.now)
+    schedule.update(start_time: Time.current)
     expect(schedule.valid?).to be_truthy
     schedule.start_time = "I'm a string"
     expect(schedule.valid?).to be_falsey
@@ -52,7 +52,7 @@ RSpec.describe Schedule, type: :model do
   end
 
   it 'validates end_time as a time' do
-    schedule.update(end_time: Time.zone.now)
+    schedule.update(end_time: Time.current)
     expect(schedule.valid?).to be_truthy
     schedule.end_time = "I'm a string"
     expect(schedule.valid?).to be_falsey

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe User, type: :model do
   end
 
   describe '#latest_attendance_in_month_utc' do
-    let!(:six_months_ago) { Time.now.in_time_zone(user.timezone).at_beginning_of_month - 6.months }
+    let!(:six_months_ago) { Time.current.in_time_zone(user.timezone).at_beginning_of_month - 6.months }
     let!(:first_attendance) do
       create(:attendance,
              check_in: six_months_ago,
@@ -53,15 +53,15 @@ RSpec.describe User, type: :model do
                                                   business: create(:business, user: user))))
     end
     let!(:second_attendance) { create(:attendance, check_in: six_months_ago + 2.days, child_approval: first_attendance.child_approval) }
-    let!(:third_attendance) { create(:attendance, check_in: Time.now.in_time_zone(user.timezone).at_beginning_of_day, child_approval: first_attendance.child_approval) }
+    let!(:third_attendance) { create(:attendance, check_in: Time.current.in_time_zone(user.timezone).at_beginning_of_day, child_approval: first_attendance.child_approval) }
     it 'works without a date passed' do
       expect(user.latest_attendance_in_month_utc(nil)).to eq(third_attendance.check_in)
     end
     it 'returns nil for a month without an attendance' do
-      expect(user.latest_attendance_in_month_utc(Time.now.in_time_zone(user.timezone).at_beginning_of_day - 2.months)).to eq(nil)
+      expect(user.latest_attendance_in_month_utc(Time.current.in_time_zone(user.timezone).at_beginning_of_day - 2.months)).to eq(nil)
     end
     it 'returns the latest attendance for a month with multiple attendances' do
-      expect(user.latest_attendance_in_month_utc(Time.now.in_time_zone(user.timezone).at_beginning_of_day - 6.months)).to eq(second_attendance.check_in)
+      expect(user.latest_attendance_in_month_utc(Time.current.in_time_zone(user.timezone).at_beginning_of_day - 6.months)).to eq(second_attendance.check_in)
     end
   end
 end

--- a/spec/requests/api/v1/attendances_spec.rb
+++ b/spec/requests/api/v1/attendances_spec.rb
@@ -18,9 +18,7 @@ RSpec.describe 'Api::V1::Attendances', type: :request do
   describe 'GET /api/v1/attendances' do
     include_context 'correct api version header'
 
-    before do
-      sign_in logged_in_user
-    end
+    before { sign_in logged_in_user }
 
     context 'when sent with a filter date' do
       let(:params) { { filter_date: (Time.zone.today - 2.weeks).at_end_of_week(:saturday) } }

--- a/spec/requests/api/v1/businesses_spec.rb
+++ b/spec/requests/api/v1/businesses_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe 'Api::V1::Businesses', type: :request do
     include_context 'correct api version header'
 
     context 'for non-admin user' do
-      before do
-        sign_in logged_in_user
-      end
+      before { sign_in logged_in_user }
 
       it "returns the user's businesses" do
         get '/api/v1/businesses', headers: headers
@@ -26,9 +24,7 @@ RSpec.describe 'Api::V1::Businesses', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it "returns all users' businesses" do
         get '/api/v1/businesses', headers: headers
@@ -44,9 +40,7 @@ RSpec.describe 'Api::V1::Businesses', type: :request do
     include_context 'correct api version header'
 
     context 'for non-admin user' do
-      before do
-        sign_in logged_in_user
-      end
+      before { sign_in logged_in_user }
 
       it "returns the user's business" do
         get "/api/v1/businesses/#{user_business.id}", headers: headers
@@ -62,9 +56,7 @@ RSpec.describe 'Api::V1::Businesses', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it "returns the user's business" do
         get "/api/v1/businesses/#{user_business.id}", headers: headers
@@ -98,9 +90,7 @@ RSpec.describe 'Api::V1::Businesses', type: :request do
     let(:params_with_user) { { business: params_without_user[:business].merge({ user_id: logged_in_user.id }) } }
 
     context 'for non-admin user' do
-      before do
-        sign_in logged_in_user
-      end
+      before { sign_in logged_in_user }
 
       it 'creates a business for that user' do
         post '/api/v1/businesses', params: params_without_user, headers: headers
@@ -112,9 +102,7 @@ RSpec.describe 'Api::V1::Businesses', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it 'creates a business for the passed user' do
         post '/api/v1/businesses', params: params_with_user, headers: headers
@@ -143,9 +131,7 @@ RSpec.describe 'Api::V1::Businesses', type: :request do
     end
 
     context 'for non-admin user' do
-      before do
-        sign_in logged_in_user
-      end
+      before { sign_in logged_in_user }
 
       it "updates the user's business" do
         put "/api/v1/businesses/#{user_business.id}", params: params, headers: headers
@@ -168,9 +154,7 @@ RSpec.describe 'Api::V1::Businesses', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it "updates the user's business" do
         put "/api/v1/businesses/#{user_business.id}", params: params, headers: headers
@@ -207,9 +191,7 @@ RSpec.describe 'Api::V1::Businesses', type: :request do
     include_context 'correct api version header'
 
     context 'for non-admin user' do
-      before do
-        sign_in logged_in_user
-      end
+      before { sign_in logged_in_user }
 
       it "soft-deletes the user's business if there are no active children" do
         user_business.children.destroy_all
@@ -226,9 +208,7 @@ RSpec.describe 'Api::V1::Businesses', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it "soft-deletes the user's business if there are no active children" do
         user_business.children.destroy_all

--- a/spec/requests/api/v1/children_spec.rb
+++ b/spec/requests/api/v1/children_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe 'Api::V1::Children', type: :request do
     include_context 'correct api version header'
 
     context 'for non-admin user' do
-      before do
-        sign_in logged_in_user
-      end
+      before { sign_in logged_in_user }
 
       it "returns the user's children" do
         get '/api/v1/children', headers: headers
@@ -28,9 +26,7 @@ RSpec.describe 'Api::V1::Children', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it "returns all users' children" do
         get '/api/v1/children', headers: headers
@@ -46,9 +42,7 @@ RSpec.describe 'Api::V1::Children', type: :request do
     include_context 'correct api version header'
 
     context 'for non-admin user' do
-      before do
-        sign_in logged_in_user
-      end
+      before { sign_in logged_in_user }
 
       it "returns the user's child" do
         get "/api/v1/children/#{user_children.first.id}", headers: headers
@@ -64,9 +58,7 @@ RSpec.describe 'Api::V1::Children', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it "returns the user's child" do
         get "/api/v1/children/#{user_children.first.id}", headers: headers
@@ -100,9 +92,7 @@ RSpec.describe 'Api::V1::Children', type: :request do
     let(:params_without_business) { { child: params[:child].except(:business_id) } }
 
     context 'for non-admin user' do
-      before do
-        sign_in logged_in_user
-      end
+      before { sign_in logged_in_user }
 
       it "creates a child for that user's business" do
         post '/api/v1/children', params: params, headers: headers
@@ -212,9 +202,7 @@ RSpec.describe 'Api::V1::Children', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it 'creates a child for the passed business' do
         post '/api/v1/children', params: params, headers: headers
@@ -243,9 +231,7 @@ RSpec.describe 'Api::V1::Children', type: :request do
     end
 
     context 'for non-admin user' do
-      before do
-        sign_in logged_in_user
-      end
+      before { sign_in logged_in_user }
 
       it "updates the user's child" do
         put "/api/v1/children/#{user_children.first.id}", params: params, headers: headers
@@ -272,9 +258,7 @@ RSpec.describe 'Api::V1::Children', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it "updates the user's child" do
         put "/api/v1/children/#{user_children.first.id}", params: params, headers: headers
@@ -298,9 +282,7 @@ RSpec.describe 'Api::V1::Children', type: :request do
     include_context 'correct api version header'
 
     context 'for non-admin user' do
-      before do
-        sign_in logged_in_user
-      end
+      before { sign_in logged_in_user }
 
       it "soft-deletes the user's child" do
         delete "/api/v1/children/#{user_children.first.id}", headers: headers
@@ -310,9 +292,7 @@ RSpec.describe 'Api::V1::Children', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it "soft-deletes the user's child" do
         delete "/api/v1/children/#{user_children.first.id}", headers: headers

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
     include_context 'correct api version header'
 
     context 'for non-admin user' do
-      before do
-        sign_in logged_in_user
-      end
+      before { sign_in logged_in_user }
 
       it 'returns only the user' do
         get '/api/v1/users', headers: headers
@@ -28,9 +26,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it 'returns all users' do
         get '/api/v1/users', headers: headers
@@ -47,9 +43,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
     include_context 'correct api version header'
 
     context 'for non-admin user' do
-      before do
-        sign_in logged_in_user
-      end
+      before { sign_in logged_in_user }
 
       it 'returns the user using their ID' do
         get "/api/v1/users/#{logged_in_user.id}", headers: headers
@@ -74,9 +68,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it 'returns the user' do
         get "/api/v1/users/#{logged_in_user.id}", headers: headers
@@ -136,9 +128,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
     end
 
     context 'for non-admin user in illinois' do
-      before do
-        sign_in illinois_user
-      end
+      before { sign_in illinois_user }
 
       it 'returns the correct data schema' do
         get '/api/v1/case_list_for_dashboard', headers: headers
@@ -158,9 +148,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
     end
 
     context 'for non-admin user in nebraska' do
-      before do
-        sign_in nebraska_user
-      end
+      before { sign_in nebraska_user }
 
       it 'returns the correct data schema' do
         get '/api/v1/case_list_for_dashboard', headers: headers
@@ -180,9 +168,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
     end
 
     context 'for admin user' do
-      before do
-        sign_in admin_user
-      end
+      before { sign_in admin_user }
 
       it 'returns the correct data schema' do
         get '/api/v1/case_list_for_dashboard', headers: headers

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -10,6 +10,6 @@ module Helpers
   end
 
   def last_elapsed_date(date)
-    Date.parse(date).month > Time.zone.now.month ? Date.parse("#{date}, #{Time.zone.now.year - 1}") : Date.parse("#{date}, #{Time.zone.now.year}")
+    Date.parse(date).month > Time.current.month ? Date.parse("#{date}, #{Time.current.year - 1}") : Date.parse("#{date}, #{Time.current.year}")
   end
 end


### PR DESCRIPTION
Ensures consistent use of Time.current, sets timezone in specs to UTC so we can catch timezone errors for CI locally
