### PR TITLE
Adds NE attendance logic

### DIFF
--- a/lib/tasks/attendances.rake
+++ b/lib/tasks/attendances.rake
@@ -28,9 +28,7 @@ def active_child_approval
 end
 
 def current_approval_amounts
-  if @child.state == 'IL'
-    active_child_approval.illinois_approval_amounts.find_by('month = ?', now.beginning_of_month)
-  end
+  active_child_approval.illinois_approval_amounts.find_by('month = ?', now.beginning_of_month) if @child.state == 'IL'
 end
 
 def weeks_to_populate

--- a/lib/tasks/attendances.rake
+++ b/lib/tasks/attendances.rake
@@ -28,9 +28,7 @@ def active_child_approval
 end
 
 def current_approval_amounts
-  if @child.state == 'NE'
-    puts 'No attendance logic for Nebraska has been implemented'
-  else
+  if @child.state == 'IL'
     active_child_approval.illinois_approval_amounts.find_by('month = ?', now.beginning_of_month)
   end
 end
@@ -101,8 +99,8 @@ end
 
 def generate_nebraska_attendance
   # create a random number of attendances based on their schedule
-  rand(0..(weeks_to_populate.to_i)).times do |week|
-    @child.schedules.each do |_schedule|
+  weeks_to_populate.to_i.times do |week|
+    @child.schedules.each do
       rand(0..1) == 1 ? add_attendance('full_day_ne', week) : add_attendance('hourly_ne', week)
     end
   end


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Closes #1539 

This adds Nebraska logic to the seed data for attendances.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
You'll need rates in order to get the attendances to return earned revenue, so if you need that, run `bundle exec rails nebraska_rates20210813` first.

Run `bundle exec rails attendances`

You should now see attendances for Nebraska kids.