### PR TITLE
remove n/a stats and logic to not show other stats if 0

### DIFF
--- a/client/src/Dashboard/Dashboard.js
+++ b/client/src/Dashboard/Dashboard.js
@@ -53,7 +53,7 @@ export function Dashboard() {
   const handleDefinitionsPanel = () => setActiveKey(activeKey === 1 ? null : 1)
 
   const generateSummaryData = (td = tableData, totals = summaryDataTotals) => {
-    if (user.state === 'NE' && totals.earnedRevenueTotal >= 0) {
+    if (user.state === 'NE') {
       return [
         {
           title: t('earnedRevenue'),
@@ -68,35 +68,35 @@ export function Dashboard() {
             totals.estimatedRevenueTotal.toFixed()
           )}`,
           definition: t(`estimatedRevenueDef`)
-        },
-        {
-          title: t(`maxRevenue`),
-          stat: `${
-            totals.maxRevenueTotal === 'n/a'
-              ? totals.maxRevenueTotal
-              : currencyFormatter.format(totals.maxRevenueTotal.toFixed())
-          }`,
-          definition: t(`comingSoon`)
-        },
-        [
-          {
-            title: t(`totalApproved`),
-            stat: `${
-              totals.totalApprovedTotal === 'n/a'
-                ? totals.totalApprovedTotal
-                : currencyFormatter.format(totals.totalApprovedTotal.toFixed())
-            }`,
-            definition: t(`comingSoon`)
-          },
-          {
-            title: t(`totalApprovedWithFamilyFee`),
-            stat: 'n/a',
-            // `${currencyFormatter.format(
-            //   totals.totalApprovedRevenueWithFamilyFeeTotal.toFixed()
-            // )}`
-            definition: t(`comingSoon`)
-          }
-        ]
+        }
+        // {
+        //   title: t(`maxRevenue`),
+        //   stat: `${
+        //     totals.maxRevenueTotal === 'n/a'
+        //       ? totals.maxRevenueTotal
+        //       : currencyFormatter.format(totals.maxRevenueTotal.toFixed())
+        //   }`,
+        //   definition: t(`comingSoon`)
+        // },
+        // [
+        //   {
+        //     title: t(`totalApproved`),
+        //     stat: `${
+        //       totals.totalApprovedTotal === 'n/a'
+        //         ? totals.totalApprovedTotal
+        //         : currencyFormatter.format(totals.totalApprovedTotal.toFixed())
+        //     }`,
+        //     definition: t(`comingSoon`)
+        //   },
+        //   {
+        //     title: t(`totalApprovedWithFamilyFee`),
+        //     stat: 'n/a',
+        //     // `${currencyFormatter.format(
+        //     //   totals.totalApprovedRevenueWithFamilyFeeTotal.toFixed()
+        //     // )}`
+        //     definition: t(`comingSoon`)
+        //   }
+        // ]
       ]
     } else if (totals.guaranteedRevenueTotal >= 0) {
       return [


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
This resolves #1697 confirm dashboard stats are removed and showing if 0
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write & run tests and linters?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally
<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
