### PR TITLE
Added record payment modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,10 @@ spec/cypress/screenshots
 
 # yarn releases
 .yarn
+.yarnrc
 
 Dockerfile
 init.sql
 .docker-env/development/database
+
+.idea/

--- a/client/src/Dashboard/DashboardTitle.js
+++ b/client/src/Dashboard/DashboardTitle.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import PropTypes from 'prop-types'
-import { Button, Grid, Typography, Select } from 'antd'
-import { PlusOutlined } from '@ant-design/icons'
+import { Button, Grid, Typography, Select, Menu, Dropdown, Modal } from 'antd'
+import { LeftOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import '_assets/styles/dashboard-overrides.css'
+import PaymentModal from '../Payment'
 
 const { useBreakpoint } = Grid
 const { Option } = Select
@@ -17,6 +18,7 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
   // const [isDropdownVisible, setDropdownVisible] = useState(false)
   // const dropdownStyle = { color: '#006C9E' }
   const [dateFilterValue, setDateFilterValue] = useState(dates.dateFilterValue)
+  const [isPaymentModalVisible, setPaymentModalVisible] = useState(false)
 
   const matchAndReplaceDate = (dateString = '') => {
     const match = dateString.match(/^[A-Za-z]+/)
@@ -47,6 +49,53 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
         </Option>
       ))}
     </Select>
+  )
+
+  const showPaymentModal = () => {
+    setPaymentModalVisible(true)
+  }
+
+  const handlePaymentModalCancel = () => {
+    setPaymentModalVisible(false)
+  }
+
+  const dashboardActions = (
+    <Menu>
+      <Menu.Item key="addAttendance">
+        <Button onClick={() => history.push('/attendance')} type="text">
+          {t('addAttendance')}
+        </Button>
+      </Menu.Item>
+      <Menu.Item key="recordPaymentButtonq">
+        <Button type="text" onClick={showPaymentModal}>
+          {t('recordPaymentButton')}
+        </Button>
+      </Menu.Item>
+    </Menu>
+  )
+
+  const dashboardActionDropdown = (
+    <Dropdown
+      overlay={dashboardActions}
+      className="ml-auto flex"
+      trigger="click"
+    >
+      <Button type="primary">
+        {t('recordDropdown')} <LeftOutlined />
+      </Button>
+    </Dropdown>
+  )
+
+  const paymentModal = (
+    <Modal
+      title={
+        <div className="eyebrow-large text-center">{t('recordAPayment')}</div>
+      }
+      visible={isPaymentModalVisible}
+      onCancel={handlePaymentModalCancel}
+    >
+      <PaymentModal />
+    </Modal>
   )
 
   const renderDisabledMonth = () => (
@@ -82,13 +131,11 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
             <Typography.Text className="mb-3 text-base">
               {t('revenueProjections')}
             </Typography.Text>
-            <Button
-              className="border-primaryBlue text-primaryBlue flex"
-              onClick={() => history.push('/attendance')}
-            >
-              {t('addAttendance')} <PlusOutlined />
-            </Button>
+
+            {dashboardActionDropdown}
           </div>
+
+          {paymentModal}
         </div>
       ) : (
         <div>
@@ -104,16 +151,14 @@ export default function DashboardTitle({ dates, userState, getDashboardData }) {
             <Typography.Text className="text-gray3">
               {`${t(`asOf`)}: ${matchAndReplaceDate(dates.asOf)}`}
             </Typography.Text>
-            <Button
-              className="ml-auto border-primaryBlue text-primaryBlue flex"
-              onClick={() => history.push('/attendance')}
-            >
-              {t('addAttendance')} <PlusOutlined />
-            </Button>
+
+            {dashboardActionDropdown}
           </div>
           <Typography.Text className="text-base">
             {t('revenueProjections')}
           </Typography.Text>
+
+          {paymentModal}
         </div>
       )}
     </div>

--- a/client/src/Payment/index.js
+++ b/client/src/Payment/index.js
@@ -1,0 +1,1 @@
+export { PaymentModal as default } from './paymentModal'

--- a/client/src/Payment/paymentModal.js
+++ b/client/src/Payment/paymentModal.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+export function PaymentModal() {
+  const { t } = useTranslation()
+
+  return (
+    <div>
+      <p>{t('recordAChildsPayment')}</p>
+    </div>
+  )
+}

--- a/client/src/i18n/locales/en/index.json
+++ b/client/src/i18n/locales/en/index.json
@@ -221,5 +221,9 @@
   "addAnotherDate": "Add another date",
   "success": "Success!",
   "successText": "You just entered some attendance history for the kids in your care.",
-  "gotToDashboard": "Go to dashboard"
+  "gotToDashboard": "Go to dashboard",
+  "recordDropdown": "Record new",
+  "recordPaymentButton": "Payment",
+  "recordAPayment": "Record a payment",
+  "recordAChildsPayment": "Record each child's payment to check if there are any inconsistencies"
 }

--- a/client/src/i18n/locales/es/index.json
+++ b/client/src/i18n/locales/es/index.json
@@ -221,5 +221,9 @@
   "addAnotherDate": "Otra fecha",
   "success": "¡Registro exitoso!",
   "successText": "Acabas de registrar el historial de asistencia para los niños bajo tu supervisión.",
-  "gotToDashboard": "Ir al panel principal"
+  "gotToDashboard": "Ir al panel principal",
+  "recordDropdown": "Anotar nuevo",
+  "recordPaymentButton": "Pago",
+  "recordAPayment": "Anota un pago",
+  "recordAChildsPayment": "Anota el pago de cada niño para chequear si haya contradicciones"
 }


### PR DESCRIPTION
Moved the add attendance button to dashboard actions dropdown menu with the record payment modal

## 💅🏼 What issue does this fix?
https://github.com/pieforproviders/pieforproviders/issues/1613

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [Yes] Did you write & run tests and linters?
* [No ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [Yes] Does your PR contain any required translations?
* [No] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [No] Migrations
* [No] Dependencies

## 🧵 Steps to set up locally
<!--
A list of things you need to change to get the code going
* Any new environment variables - No
* Any build steps - No
* Any docker changes - No
* Any migrations or tasks that need to run manually - No
-->

## 🧳 Steps to test
To confirm these changes, make sure the Record new dropdown is shown on Medium/Small screens. This dropdown should have the attendance record and payment buttons. Clicking attendance record should take you to original record attendance screen. Clicking payment should open up a modal with some text. 

## 🕯 Caveats, concerns
No concerns
