### PR TITLE
disable next button on week picker if in current week

### DIFF
--- a/client/src/AttendanceView/AttendanceView.js
+++ b/client/src/AttendanceView/AttendanceView.js
@@ -188,6 +188,7 @@ export function AttendanceView() {
           </div>
           <p>
             <WeekPicker
+              hasNext={dateSelected.day(6) < dayjs().day(0)}
               dateSelected={dateSelected}
               handleDateChange={handleDateChange}
             />

--- a/client/src/AttendanceView/WeekPicker.js
+++ b/client/src/AttendanceView/WeekPicker.js
@@ -3,10 +3,16 @@ import PropTypes from 'prop-types'
 import { Button } from 'antd'
 import { LeftOutlined, RightOutlined } from '@ant-design/icons'
 
-export function WeekPicker({ dateSelected, handleDateChange }) {
+export function WeekPicker({
+  dateSelected,
+  handleDateChange,
+  hasPrev = true,
+  hasNext = true
+}) {
   return (
     <div>
       <Button
+        disabled={!hasPrev}
         onClick={() => handleDateChange(dateSelected.weekday(-7))}
         data-cy="backWeekButton"
       >
@@ -24,6 +30,7 @@ export function WeekPicker({ dateSelected, handleDateChange }) {
           dateSelected.weekday(6).format('MMM D, YYYY')}
       </Button>
       <Button
+        disabled={!hasNext}
         onClick={() => handleDateChange(dateSelected.weekday(7))}
         data-cy="forwardWeekButton"
       >
@@ -35,5 +42,7 @@ export function WeekPicker({ dateSelected, handleDateChange }) {
 
 WeekPicker.propTypes = {
   dateSelected: PropTypes.object,
-  handleDateChange: PropTypes.func
+  handleDateChange: PropTypes.func,
+  hasPrev: PropTypes.bool,
+  hasNext: PropTypes.bool
 }


### PR DESCRIPTION
Disable the next button on the week picker on the attendance page when viewing the current week but enabled it when viewing past weeks

## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

https://github.com/pieforproviders/pieforproviders/issues/1725

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write & run tests and linters?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally
<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
