### PR TITLE
Fixes the screen resolution of the small size content test

### DIFF
--- a/spec/cypress/integration/attendanceView.spec.js
+++ b/spec/cypress/integration/attendanceView.spec.js
@@ -79,7 +79,7 @@ describe('AttendanceView', () => {
 
   describe('content', () => {
     it('renders content', () => {
-      cy.viewport(500, 500)
+      cy.viewport(768, 500)
       cy.contains(childFullName)
       cy.contains('4 hrs 0 mins')
       cy.contains('Input Attendance')


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

The "renders content" test was still set too small to get the right display, so I bumped it to our 768 small size

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write & run tests and linters?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally
<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
