### PR TITLE
Turn off compile-mermaid workflow on tags

### DIFF
--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -6,6 +6,8 @@ on:
       - '**/*.mermaid'
       - '**/*.mmd'
       - '**/*.md'
+    tags-ignore:
+      - '**'
 
 jobs:
   compile-mermaid:


### PR DESCRIPTION
Fixes the compile-mermaid workflow so it won't run on tags, i.e. when we do a release

## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
No ticket associated with this, just github actions changes