### PR TITLE
Uses runtime env vars rather than build time env vars

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -39,7 +39,7 @@ const Routes = () => {
       initHotjar(env.REACT_APP_HOTJAR_ID, env.REACT_APP_HOTJAR_SV)
     }
     if (!window.gtag) return
-    window.gtag('config', process.env.REACT_APP_GA_MEASUREMENT_ID, {
+    window.gtag('config', env.REACT_APP_GA_MEASUREMENT_ID, {
       page_path: location.pathname,
       user_id: user.id ?? ''
     })


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Closes #1898 - changes the env var that's called to the runtime envs, so we can use the prod value for google analytics