### PR TITLE
[PIE-1866] [PIE-1862] [PIE-1724] [PIE-1867] service_days endpoint, tags

### DIFF
--- a/app/blueprints/service_day_blueprint.rb
+++ b/app/blueprints/service_day_blueprint.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Serializer for service_days
+class ServiceDayBlueprint < Blueprinter::Base
+  identifier :id
+  field :child_id
+  field :date
+  field :tags
+  # rubocop:disable Style/SymbolProc
+  field :total_time_in_care do |service_day|
+    service_day.total_time_in_care
+  end
+  # rubocop:enable Style/SymbolProc
+  association :attendances, blueprint: AttendanceBlueprint
+end

--- a/app/controllers/api/v1/service_days_controller.rb
+++ b/app/controllers/api/v1/service_days_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # API for user service_days
+    class ServiceDaysController < Api::V1::ApiController
+      # GET /service_days
+      def index
+        @service_days = policy_scope(ServiceDay).for_week(filter_date)
+
+        render json: ServiceDayBlueprint.render(@service_days)
+      end
+
+      private
+
+      def filter_date
+        params[:filter_date] ? Time.zone.parse(params[:filter_date]) : nil
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/service_days_controller.rb
+++ b/app/controllers/api/v1/service_days_controller.rb
@@ -6,7 +6,7 @@ module Api
     class ServiceDaysController < Api::V1::ApiController
       # GET /service_days
       def index
-        @service_days = policy_scope(ServiceDay.includes(:attendances)).for_week(filter_date)
+        @service_days = policy_scope(ServiceDay.includes(:attendances, :child)).for_week(filter_date)
 
         render json: ServiceDayBlueprint.render(@service_days)
       end

--- a/app/controllers/api/v1/service_days_controller.rb
+++ b/app/controllers/api/v1/service_days_controller.rb
@@ -6,7 +6,7 @@ module Api
     class ServiceDaysController < Api::V1::ApiController
       # GET /service_days
       def index
-        @service_days = policy_scope(ServiceDay).for_week(filter_date)
+        @service_days = policy_scope(ServiceDay.includes(:attendances)).for_week(filter_date)
 
         render json: ServiceDayBlueprint.render(@service_days)
       end

--- a/app/models/service_day.rb
+++ b/app/models/service_day.rb
@@ -79,6 +79,37 @@ class ServiceDay < UuidApplicationRecord
     attendances.any? { |attendance| attendance.absence.present? }
   end
 
+  def tags
+    [
+      hourly? || daily_plus_hourly? || daily_plus_hourly_max? ? 'hourly' : nil,
+      daily? || daily_plus_hourly? || daily_plus_hourly_max? ? 'daily' : nil
+    ].compact
+  end
+
+  def hourly?
+    return unless state == 'NE'
+
+    total_time_in_care <= (5.hours + 45.minutes)
+  end
+
+  def daily?
+    return unless state == 'NE'
+
+    total_time_in_care > (5.hours + 45.minutes) && total_time_in_care <= 10.hours
+  end
+
+  def daily_plus_hourly?
+    return unless state == 'NE'
+
+    total_time_in_care > 10.hours && total_time_in_care <= 18.hours
+  end
+
+  def daily_plus_hourly_max?
+    return unless state == 'NE'
+
+    total_time_in_care > 18.hours
+  end
+
   def earned_revenue
     return unless state == 'NE'
 

--- a/app/policies/service_day_policy.rb
+++ b/app/policies/service_day_policy.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Authorization policies for service_days
+class ServiceDayPolicy < ApplicationPolicy
+  # Scope defining which service_days a user has access to
+  class Scope < ApplicationScope
+    def resolve
+      if user.admin?
+        scope.all
+      else
+        scope.joins(child: {
+                      business: :user
+                    }).where(children: { businesses: { user: user } })
+      end
+    end
+  end
+end

--- a/client/src/AttendanceView/AttendanceView.js
+++ b/client/src/AttendanceView/AttendanceView.js
@@ -101,7 +101,7 @@ export function AttendanceView() {
                   {checkInCheckOutTime}
                 </div>
                 <div className="bg-green2 text-green1 box-border p-1">
-                  {matchingAttendances[0].tags.forEach(tag =>
+                  {(matchingAttendances[0]?.tags || []).forEach(tag =>
                     t(`${tag.toLowerCase()}`)
                   )}
                 </div>
@@ -157,14 +157,55 @@ export function AttendanceView() {
 
       if (response.ok) {
         const parsedResponse = await response.json()
-        // const mockParsedResponse =  [
-        //   "date": "2021-01-03",
-        //   "tags": ["full_day", "hourly"],
-        //   "attendances": [
-        //   ]
-        // ]
-        // eslint-disable-next-line no-debugger
-        debugger
+        const mockParsedResponse = [
+          {
+            date: '2021-01-03',
+            tags: ['full_day', 'hourly'],
+            attendances: [
+              {
+                absence: 'absence',
+                check_in: '2021-11-01 00:00:00 -0600',
+                check_out: null,
+                child: {
+                  id: 'c2d629d7-49a2-422d-ac45-10e78c654666',
+                  active: true,
+                  full_name: 'Rhonan Shaw',
+                  inactive_reason: null,
+                  last_active_date: null
+                },
+                child_approval_id: 'f0cd2194-834e-4758-9a75-41925c6a0fa6',
+                id: '389db1c0-5075-42de-b7a3-06f38766aacf',
+                total_time_in_care: '3600'
+              }
+            ]
+          }
+        ]
+        // eslint-disable-next-line no-unused-vars
+        const reduceAttendances = attendances => {
+          return attendances.reduce((accumulator, currentValue) => {
+            // eslint-disable-next-line no-constant-condition
+            if (
+              accumulator.some(e => e.child === currentValue.child.full_name)
+            ) {
+              return accumulator.map(child => {
+                if (child.child === currentValue.child.full_name) {
+                  return {
+                    child: child.child,
+                    attendances: [...child.attendances, currentValue]
+                  }
+                } else {
+                  return child
+                }
+              })
+            } else {
+              return [
+                ...accumulator,
+                // eslint-disable-next-line prettier/prettier
+                { child: currentValue.child.full_name, attendances: [currentValue] }
+              ]
+            }
+          }, [])
+        }
         const reducedAttendanceData = parsedResponse.reduce(
           (accumulator, currentValue) => {
             // eslint-disable-next-line no-constant-condition
@@ -191,7 +232,11 @@ export function AttendanceView() {
           },
           []
         )
-
+        console.log(
+          mockParsedResponse.flatMap(res => reduceAttendances(res.attendances))
+        )
+        // eslint-disable-next-line no-debugger
+        debugger
         setAttendanceData(reducedAttendanceData)
         setColumns(generateColumns())
       }

--- a/client/src/AttendanceView/AttendanceView.js
+++ b/client/src/AttendanceView/AttendanceView.js
@@ -50,6 +50,23 @@ export function AttendanceView() {
             )
           })
           if (matchingAttendances.length > 0) {
+            if (
+              matchingAttendances.some(
+                attendance => attendance.tag === 'absent'
+              )
+            ) {
+              return (
+                <div className="flex justify-center">
+                  <div
+                    className="bg-orange2 text-orange3 box-border p-1"
+                    data-cy="absent"
+                  >
+                    {t('absent').toLowerCase()}
+                  </div>
+                </div>
+              )
+            }
+
             let totalCareTime = '',
               checkInCheckOutTime = ''
             matchingAttendances.forEach(attendance => {
@@ -73,6 +90,8 @@ export function AttendanceView() {
                   ? totalCareTime + ', ' + hour + ' hrs ' + minute + '  mins'
                   : hour + ' hrs ' + minute + '  mins'
             })
+            // eslint-disable-next-line no-debugger
+            debugger
             return (
               <div className="body-2 text-center">
                 <div className="text-gray8 font-semiBold mb-2">
@@ -80,6 +99,11 @@ export function AttendanceView() {
                 </div>
                 <div className="text-darkGray text-xs">
                   {checkInCheckOutTime}
+                </div>
+                <div className="bg-green2 text-green1 box-border p-1">
+                  {matchingAttendances[0].tags.forEach(tag =>
+                    t(`${tag.toLowerCase()}`)
+                  )}
                 </div>
               </div>
             )
@@ -133,6 +157,14 @@ export function AttendanceView() {
 
       if (response.ok) {
         const parsedResponse = await response.json()
+        // const mockParsedResponse =  [
+        //   "date": "2021-01-03",
+        //   "tags": ["full_day", "hourly"],
+        //   "attendances": [
+        //   ]
+        // ]
+        // eslint-disable-next-line no-debugger
+        debugger
         const reducedAttendanceData = parsedResponse.reduce(
           (accumulator, currentValue) => {
             // eslint-disable-next-line no-constant-condition

--- a/client/src/AttendanceView/_tests_/AttendanceView.test.js
+++ b/client/src/AttendanceView/_tests_/AttendanceView.test.js
@@ -17,7 +17,7 @@ describe('<AttendanceView />', () => {
     await waitFor(() => {
       expect(window.fetch).toHaveBeenCalledTimes(1)
       expect(window.fetch.mock.calls[0][0]).toBe(
-        '/api/v1/attendances?filter_date=' + dayjs().format('YYYY-MM-DD')
+        '/api/v1/service_days?filter_date=' + dayjs().format('YYYY-MM-DD')
       )
     })
   })

--- a/client/src/i18n/locales/en/index.json
+++ b/client/src/i18n/locales/en/index.json
@@ -238,5 +238,8 @@
 
   "screenSize": "Screen size not compatible",
   "incompatibleMsg": "Either your browser window is too small, or you’re on a mobile device. Please switch to a desktop or tablet to view this page.",
-  "noInfo": "no info"
+  "noInfo": "no info",
+
+  "daily": "full day",
+  "hourly": "hours"
 }

--- a/client/src/i18n/locales/es/index.json
+++ b/client/src/i18n/locales/es/index.json
@@ -238,5 +238,8 @@
 
   "screenSize": "Tamaño de pantalla no compatible",
   "incompatibleMsg": "O tu navegador es demasiado pequeño o estás en un aparato móvil. Por favor cambia a una computadora o tableta para ver esta pagina.",
-  "noInfo": "no info"
+  "noInfo": "no info",
+
+  "daily": "día completo",
+  "hourly": "horas"
 }

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -22,6 +22,7 @@ module.exports = {
         red2: '#FFEDED',
         orange1: '#F8921F',
         orange2: '#FAE7D1',
+        orange3: '#9C4814',
         green1: '#00853D',
         green2: '#DCFAEA',
         blueOverlay: '#004A6E80'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
       resources :businesses
       resources :children
       resources :attendances, only: :index
+      resources :service_days, only: :index
       resources :attendance_batches, only: :create
       get 'case_list_for_dashboard', to: 'users#case_list_for_dashboard'
     end

--- a/spec/blueprints/service_day_blueprint_spec.rb
+++ b/spec/blueprints/service_day_blueprint_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ServiceDayBlueprint do
+  let(:service_day) { create(:attendance).service_day }
+  let(:blueprint) { described_class.render(service_day) }
+
+  it 'returns the correct fields' do
+    expect(JSON.parse(blueprint).keys).to contain_exactly(
+      'attendances',
+      'id',
+      'child_id',
+      'date',
+      'tags',
+      'total_time_in_care'
+    )
+  end
+end

--- a/spec/policies/service_day_policy_spec.rb
+++ b/spec/policies/service_day_policy_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ServiceDayPolicy do
+  subject { described_class }
+
+  let(:user) { create(:confirmed_user) }
+  let(:non_owner) { create(:confirmed_user) }
+  let(:business) { create(:business, user: user) }
+  let(:admin) { create(:admin) }
+  let(:child) { create(:child, business: business) }
+  let(:child_approval) { child.child_approvals.first }
+  let(:attendance) { create(:attendance, child_approval: child_approval) }
+  let(:service_day) { attendance.service_day }
+
+  describe ServiceDayPolicy::Scope do
+    context 'when authenticated as an admin' do
+      it 'returns all service_days' do
+        service_days = described_class.new(admin, ServiceDay).resolve
+        expect(service_days).to match_array([service_day])
+      end
+    end
+
+    context 'when logged in as an owner user' do
+      it 'returns the service_days associated to the user' do
+        service_days = described_class.new(user, ServiceDay).resolve
+        expect(service_days).to match_array([service_day])
+      end
+    end
+
+    context 'when logged in as a non-owner user' do
+      it 'returns an empty relation' do
+        service_days = described_class.new(non_owner, ServiceDay).resolve
+        expect(service_days).to be_empty
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/service_days_spec.rb
+++ b/spec/requests/api/v1/service_days_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Since the for_week scope on service_day model uses the Sunday to Friday week range, we should make
+# sure we don't work with a Saturday date to avoid flakiness in spec runs. A way to do this is to set
+# the week_current_date value to a day that falls within the expected week range
+
+RSpec.describe 'Api::V1::ServiceDays', type: :request do
+  let!(:logged_in_user) { create(:confirmed_user) }
+  let!(:business) { create(:business, user: logged_in_user) }
+  let!(:child) { create(:child, business: business) }
+  let!(:child_approval) { child.child_approvals.first }
+  let!(:timezone) { ActiveSupport::TimeZone.new(child.timezone) }
+
+  let!(:week_current_date) { Time.new(2021, 9, 15, 0, 0, 0, timezone) } # Wednesday
+  let!(:week_start_date) { week_current_date.at_beginning_of_week(:sunday) } # Sunday
+
+  let!(:two_weeks_ago_week_current_date) { week_current_date - 2.weeks }
+  let!(:two_weeks_ago_week_start_date) { week_start_date - 2.weeks }
+
+  let!(:this_week_service_days) do
+    build_list(:attendance, 3) do |attendance|
+      attendance.child_approval = child_approval
+      attendance.check_in = Helpers
+                            .next_attendance_day(child_approval: child_approval, date: week_start_date) +
+                            3.hours
+      attendance.check_out = Helpers
+                             .next_attendance_day(child_approval: child_approval, date: week_start_date) +
+                             9.hours + 18.minutes
+      attendance.save!
+    end.map(&:service_day)
+  end
+
+  let!(:past_service_days) do
+    [
+      create(:attendance, check_in: two_weeks_ago_week_start_date, child_approval: child_approval).service_day,
+      create(:attendance, check_in: two_weeks_ago_week_start_date + 2.days, child_approval: child_approval).service_day
+    ]
+  end
+
+  let!(:extra_service_days) do
+    build_list(:attendance, 3) do |attendance|
+      attendance.check_in = Helpers
+                            .next_attendance_day(child_approval: child_approval, date: week_start_date) +
+                            3.hours
+      attendance.check_out = Helpers
+                             .next_attendance_day(child_approval: child_approval, date: week_start_date) +
+                             9.hours + 18.minutes
+      attendance.save!
+    end.map(&:service_day)
+  end
+
+  describe 'GET /api/v1/service_days' do
+    include_context 'with correct api version header'
+
+    before do
+      travel_to week_current_date
+      sign_in logged_in_user
+    end
+
+    after { travel_back }
+
+    context 'when sent with a filter date' do
+      let(:params) { { filter_date: two_weeks_ago_week_current_date } }
+
+      it 'displays the service_days' do
+        get '/api/v1/service_days', params: params, headers: headers
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response.collect do |x|
+                 x['child_id']
+               end).to match_array(past_service_days.collect(&:child_id))
+        expect(parsed_response.collect do |x|
+                 x['date']
+               end).to match_array(past_service_days.collect(&:date))
+        expect(parsed_response.collect do |x|
+                 x['tags']
+               end).to match_array(past_service_days.collect(&:tags))
+        expect(parsed_response.collect do |x|
+          x['total_time_in_care']
+        end).to match_array(
+          past_service_days
+          .collect { |service_day| service_day.total_time_in_care.to_s }
+        )
+        expect(parsed_response.length).to eq(2)
+        expect(response).to match_response_schema('service_days')
+      end
+    end
+
+    context 'when sent without a filter date' do
+      it 'displays the service_days' do
+        get '/api/v1/service_days', params: {}, headers: headers
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response.collect do |x|
+                 x['child_id']
+               end).to match_array(this_week_service_days.collect(&:child_id))
+        expect(parsed_response.collect do |x|
+                 x['date']
+               end).to match_array(this_week_service_days.collect(&:date))
+        expect(parsed_response.collect do |x|
+                 x['tags']
+               end).to match_array(this_week_service_days.collect(&:tags))
+        expect(parsed_response.collect do |x|
+                 x['total_time_in_care']
+               end).to match_array(
+                 this_week_service_days
+                 .collect { |service_day| service_day.total_time_in_care.to_s }
+               )
+        expect(parsed_response.length).to eq(3)
+        expect(response).to match_response_schema('service_days')
+      end
+    end
+
+    context 'when viewed by an admin' do
+      before do
+        admin = create(:admin)
+        sign_in admin
+      end
+
+      it 'displays the service_days' do
+        get '/api/v1/service_days', params: {}, headers: headers
+        parsed_response = JSON.parse(response.body)
+        all_current_service_days = this_week_service_days + extra_service_days
+
+        expect(parsed_response.collect do |x|
+                 x['child_id']
+               end).to match_array(all_current_service_days.collect(&:child_id))
+        expect(parsed_response.collect do |x|
+                 x['date']
+               end).to match_array(all_current_service_days.collect(&:date))
+        expect(parsed_response.collect do |x|
+                 x['tags']
+               end).to match_array(all_current_service_days.collect(&:tags))
+        expect(parsed_response.collect do |x|
+                 x['total_time_in_care']
+               end).to match_array(
+                 all_current_service_days
+                 .collect { |service_day| service_day.total_time_in_care.to_s }
+               )
+        expect(parsed_response.length).to eq(6)
+        expect(response).to match_response_schema('service_days')
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/service_days_spec.rb
+++ b/spec/requests/api/v1/service_days_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Api::V1::ServiceDays', type: :request do
   let!(:timezone) { ActiveSupport::TimeZone.new(child.timezone) }
 
   let!(:week_current_date) { Time.new(2021, 9, 15, 0, 0, 0, timezone) } # Wednesday
-  let!(:week_start_date) { week_current_date.at_beginning_of_week(:sunday) } # Sunday
+  let!(:week_start_date) { week_current_date.in_time_zone(child.timezone).at_beginning_of_week(:sunday) } # Sunday
 
   let!(:two_weeks_ago_week_current_date) { week_current_date - 2.weeks }
   let!(:two_weeks_ago_week_start_date) { week_start_date - 2.weeks }

--- a/spec/support/api/schemas/service_day.json
+++ b/spec/support/api/schemas/service_day.json
@@ -1,0 +1,39 @@
+{
+  "properties": {
+    "attendances": {
+      "type": "array",
+      "items": {
+        "attendance": {
+          "type": "object",
+          "$ref": "attendance.json"
+        }
+      }
+    },
+    "child_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uuid"
+    },
+    "date": {
+      "type": "string",
+      "format": "time"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "total_time_in_care": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/spec/support/api/schemas/service_days.json
+++ b/spec/support/api/schemas/service_days.json
@@ -1,0 +1,6 @@
+{
+  "type": "array",
+  "items": {
+    "$ref": "service_day.json"
+  }
+}


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Closes #1866 
Closes #1862 
Closes #1724
Closes #1867

This adds a `service_days` endpoint to the API that returns an array of ServiceDays based on a filter_date, and the associated attendances, as well as the tags indicating the length of duration.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

Log in as the Nebraska user and hit the /service_days endpoint, after populating attendances in your API