### PR TITLE
[Pie-1798] I can access My Profile from the navigation

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -21,6 +21,7 @@ import Signup from './Signup'
 import NotFound from './NotFound'
 import ErrorBoundary from './ErrorBoundary'
 import CasesImport from './CasesImport'
+import Profile from './Profile'
 import { AuthLayout } from '_shared'
 import { useTranslation } from 'react-i18next'
 import { useAuthentication } from '_shared/_hooks/useAuthentication'
@@ -93,6 +94,9 @@ const Routes = () => {
         </AuthenticatedRoute>
         <AuthenticatedRoute exact path="/cases/import">
           <CasesImport />
+        </AuthenticatedRoute>
+        <AuthenticatedRoute exact path="/profile">
+          <Profile />
         </AuthenticatedRoute>
         <Route exact path="/">
           <Redirect to={isAuthenticated ? '/dashboard' : '/login'} />

--- a/client/src/Profile/Profile.js
+++ b/client/src/Profile/Profile.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function Profile() {
+  return <div>My Profile</div>
+}

--- a/client/src/Profile/index.js
+++ b/client/src/Profile/index.js
@@ -1,0 +1,1 @@
+export { Profile as default } from './Profile'

--- a/client/src/_shared/Header.js
+++ b/client/src/_shared/Header.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import pieSliceLogo from '_assets/pieSliceLogo.svg'
-import { Avatar, Button, Divider, Dropdown, Menu, Space } from 'antd'
+import { Avatar, Button, Dropdown, Menu, Space } from 'antd'
 import { MenuOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import { batch, useDispatch, useSelector } from 'react-redux'
@@ -33,7 +33,7 @@ export function Header() {
 
   const menu = (
     <Menu>
-      <Menu.Item key="0">
+      <Menu.Item key="profile">
         <Button
           className="text-lg font-semibold"
           type="link"
@@ -42,7 +42,7 @@ export function Header() {
           {t('myProfile')}
         </Button>
       </Menu.Item>
-      <Menu.Item key="1">
+      <Menu.Item key="logout">
         <Button className="text-lg font-semibold" type="link" onClick={logout}>
           {t('logout')}
         </Button>
@@ -69,7 +69,7 @@ export function Header() {
       )}
       {isAuthenticated && (
         <Dropdown overlay={menu}>
-          <Avatar className="bg-primaryBlue">
+          <Avatar className="bg-primaryBlue" data-testid="avatar">
             {user.greeting_name && user.greeting_name[0]}
           </Avatar>
         </Dropdown>
@@ -80,36 +80,39 @@ export function Header() {
   const renderMobileMenu = () => {
     const mobileMenu = (
       <Menu>
-        <Menu.Item>
-          {isAuthenticated && (
-            <Button type="link" onClick={() => history.push('/dashboard')}>
-              {t('dashboard')}
-            </Button>
-          )}
-        </Menu.Item>
-        <Menu.Item>
-          {isAuthenticated && (
-            <Button type="link" onClick={() => history.push('/attendance')}>
-              {t('attendance')}
-            </Button>
-          )}
-        </Menu.Item>
-        <Divider />
-        <Menu.Item>
-          {isAuthenticated && (
-            <Button type="link" onClick={logout}>
-              {t('logout')}
-            </Button>
-          )}
-        </Menu.Item>
+        {isAuthenticated && (
+          <>
+            <Menu.Item key="dashboard">
+              <Button type="link" onClick={() => history.push('/dashboard')}>
+                {t('dashboard')}
+              </Button>
+            </Menu.Item>
+            <Menu.Item key="attendance">
+              <Button type="link" onClick={() => history.push('/attendance')}>
+                {t('attendance')}
+              </Button>
+            </Menu.Item>
+            <Menu.Divider />
+            <Menu.Item key="profile">
+              <Button type="link" onClick={() => history.push('/profile')}>
+                {t('myProfile')}
+              </Button>
+            </Menu.Item>
+            <Menu.Item key="logout">
+              <Button type="link" onClick={logout}>
+                {t('logout')}
+              </Button>
+            </Menu.Item>
+          </>
+        )}
         {i18n.language === 'es' ? (
-          <Menu.Item>
+          <Menu.Item key="english">
             <Button type="link" onClick={() => changeLanguage('en')}>
               {t('english')}
             </Button>
           </Menu.Item>
         ) : (
-          <Menu.Item>
+          <Menu.Item key="spanish">
             <Button type="link" onClick={() => changeLanguage('es')}>
               {t('spanish')}
             </Button>

--- a/client/src/_shared/Header.js
+++ b/client/src/_shared/Header.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import pieSliceLogo from '_assets/pieSliceLogo.svg'
-import { Avatar, Button, Dropdown, Menu, Space } from 'antd'
+import { Button, Dropdown, Menu, Space } from 'antd'
 import { MenuOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import { batch, useDispatch, useSelector } from 'react-redux'
@@ -68,10 +68,15 @@ export function Header() {
         </Button>
       )}
       {isAuthenticated && (
-        <Dropdown overlay={menu}>
-          <Avatar className="bg-primaryBlue" data-testid="avatar">
+        <Dropdown overlay={menu} trigger={'click'}>
+          <Button
+            className="bg-primaryBlue"
+            type="primary"
+            shape="circle"
+            name="avatar"
+          >
             {user.greeting_name && user.greeting_name[0]}
-          </Avatar>
+          </Button>
         </Dropdown>
       )}
     </Space>

--- a/client/src/_shared/Header.js
+++ b/client/src/_shared/Header.js
@@ -4,7 +4,7 @@ import pieSliceLogo from '_assets/pieSliceLogo.svg'
 import { Avatar, Button, Divider, Dropdown, Menu, Space } from 'antd'
 import { MenuOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
-import { batch, useDispatch } from 'react-redux'
+import { batch, useDispatch, useSelector } from 'react-redux'
 import { removeAuth } from '_reducers/authReducer'
 import { deleteUser } from '_reducers/userReducer'
 import { useAuthentication } from '_shared/_hooks/useAuthentication'
@@ -17,6 +17,9 @@ export function Header() {
   const [windowWidth, setWindowWidth] = useState(window.innerWidth)
   const setWidth = () => setWindowWidth(window.innerWidth)
   const history = useHistory()
+  const { user } = useSelector(state => ({
+    user: state.user
+  }))
 
   const changeLanguage = lang => i18n.changeLanguage(lang)
 
@@ -66,7 +69,9 @@ export function Header() {
       )}
       {isAuthenticated && (
         <Dropdown overlay={menu}>
-          <Avatar className="bg-primaryBlue">U</Avatar>
+          <Avatar className="bg-primaryBlue">
+            {user.greeting_name && user.greeting_name[0]}
+          </Avatar>
         </Dropdown>
       )}
     </Space>

--- a/client/src/_shared/Header.js
+++ b/client/src/_shared/Header.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import pieSliceLogo from '_assets/pieSliceLogo.svg'
-import { Button, Divider, Dropdown, Menu } from 'antd'
+import { Avatar, Button, Divider, Dropdown, Menu, Space } from 'antd'
 import { MenuOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import { batch, useDispatch } from 'react-redux'
@@ -28,19 +28,48 @@ export function Header() {
     history.push('/login')
   }
 
-  const renderDesktopMenu = () => (
-    <>
-      {i18n.language === 'es' ? (
-        <Button onClick={() => changeLanguage('en')}>{t('english')}</Button>
-      ) : (
-        <Button onClick={() => changeLanguage('es')}>{t('spanish')}</Button>
-      )}
-      {isAuthenticated && (
-        <Button type="link" onClick={logout}>
+  const menu = (
+    <Menu>
+      <Menu.Item key="0">
+        <Button
+          className="text-lg font-semibold"
+          type="link"
+          onClick={() => history.push('/profile')}
+        >
+          {t('myProfile')}
+        </Button>
+      </Menu.Item>
+      <Menu.Item key="1">
+        <Button className="text-lg font-semibold" type="link" onClick={logout}>
           {t('logout')}
         </Button>
+      </Menu.Item>
+    </Menu>
+  )
+
+  const renderDesktopMenu = () => (
+    <Space size="middle">
+      {i18n.language === 'es' ? (
+        <Button
+          className="border-primaryBlue text-primaryBlue flex"
+          onClick={() => changeLanguage('en')}
+        >
+          {t('english')}
+        </Button>
+      ) : (
+        <Button
+          className="border-primaryBlue text-primaryBlue flex"
+          onClick={() => changeLanguage('es')}
+        >
+          {t('spanish')}
+        </Button>
       )}
-    </>
+      {isAuthenticated && (
+        <Dropdown overlay={menu}>
+          <Avatar className="bg-primaryBlue">U</Avatar>
+        </Dropdown>
+      )}
+    </Space>
   )
 
   const renderMobileMenu = () => {

--- a/client/src/_shared/__tests__/Header.test.js
+++ b/client/src/_shared/__tests__/Header.test.js
@@ -1,9 +1,20 @@
 import React from 'react'
 import { render, fireEvent, screen } from 'setupTests'
 import { Header } from '_shared'
+import dayjs from 'dayjs'
 
-const doRender = () => {
-  return render(<Header />)
+const doRender = stateOptions => {
+  return render(<Header />, stateOptions)
+}
+
+const authenticatedState = {
+  initialState: {
+    auth: {
+      token: 'whatever',
+      expiration: dayjs().add('2', 'days').format()
+    },
+    user: { greeting_name: 'User' }
+  }
 }
 
 describe('<Header />', () => {
@@ -12,11 +23,28 @@ describe('<Header />', () => {
     expect(screen.getByText(/Dashboard/)).toBeDefined()
     expect(screen.getByText(/Attendance/)).toBeDefined()
 
-    let element = screen.getByText(/Español/)
+    const element = screen.getByText(/Español/)
     fireEvent.click(element)
     expect(element).toHaveTextContent(/English/)
 
     fireEvent.click(element)
     expect(element).toHaveTextContent(/Español/)
+  })
+
+  it('displays the user avatar with username initial', () => {
+    doRender(authenticatedState)
+    const avatar = screen.getByTestId('avatar')
+
+    expect(avatar).toHaveTextContent('U')
+  })
+
+  it('displays dropdown when avatar is hovered over', async () => {
+    doRender(authenticatedState)
+    const avatar = screen.getByTestId('avatar')
+
+    fireEvent.mouseOver(avatar)
+    await screen.findByRole('button', { name: /my profile/i })
+    await screen.findByRole('button', { name: /logout/i })
+    screen.debug()
   })
 })

--- a/client/src/_shared/__tests__/Header.test.js
+++ b/client/src/_shared/__tests__/Header.test.js
@@ -33,16 +33,18 @@ describe('<Header />', () => {
 
   it('displays the user avatar with username initial', () => {
     doRender(authenticatedState)
-    const avatar = screen.getByTestId('avatar')
-
-    expect(avatar).toHaveTextContent('U')
+    screen.getByRole('button', {
+      name: /U/i
+    })
   })
 
-  it('displays dropdown when avatar is hovered over', async () => {
+  it('displays dropdown when avatar is clicked', async () => {
     doRender(authenticatedState)
-    const avatar = screen.getByTestId('avatar')
+    const avatar = screen.getByRole('button', {
+      name: /U/i
+    })
 
-    fireEvent.mouseOver(avatar)
+    fireEvent.click(avatar)
     await screen.findByRole('button', { name: /my profile/i })
     await screen.findByRole('button', { name: /logout/i })
     screen.debug()

--- a/client/src/i18n/locales/en/index.json
+++ b/client/src/i18n/locales/en/index.json
@@ -6,7 +6,7 @@
   "signup": "Sign Up",
   "or": "or",
   "login": "Log In",
-  "logout": "Log Out",
+  "logout": "Logout",
   "email": "Email",
   "password": "Password",
   "emailAddressRequired": "Email address is required",
@@ -193,6 +193,7 @@
   "sortAsc": "Click to sort ascending ",
   "sortDesc": "Click to sort descending",
   "sortCancel": "Click to cancel sort",
+  "myProfile": "My Profile",
 
   "actions": "Actions",
   "markInactive": "Mark inactive",

--- a/client/src/i18n/locales/es/index.json
+++ b/client/src/i18n/locales/es/index.json
@@ -193,6 +193,7 @@
   "sortAsc": "Ordenar ascendente",
   "sortDesc": "Ordenar descendiente",
   "sortCancel": "Cancelar orden",
+  "myProfile": "Mi Perfil",
 
   "actions": "Acciones",
   "markInactive": "Desactivar",


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
Closes #1798
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?
* [X] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [X] Does your PR contain any required translations?

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally

## 🧳 Steps to test
Desktop: Verify the presence of avatar with user's initial. Click on it, then click on "My Profile/Mi Perfil" to navigate to the dummy profile page.
Mobile: Open the hamburger menu, click on "My Profile/Mi Perfil" to navigate to the dummy profile page.

## 🕯 Caveats, concerns
- This PR does not include a selected state for "My Profile", as that's part of #1726
- A circular button was used instead of the AntD Avatar component mentioned in the issue for accessibility reasons.
