### PR TITLE
[PIE-1953] Sets the page title based on the page path

### DIFF
--- a/client/src/_shared/_hooks/useGoogleAnalytics.js
+++ b/client/src/_shared/_hooks/useGoogleAnalytics.js
@@ -14,6 +14,7 @@ export function useGoogleAnalytics() {
       page_path: location.pathname,
       user_id: user.id ?? ''
     })
+    window.gtag('set', 'page_title', location.pathname)
   }
 
   const sendGAEvent = (eventName, payload) => {


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Closes #1953 

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
Click around, then go to GA Dashboard (I went to realtime, events, page_view, and then page_title).  You should see paths instead of only seeing "Pie for Providers"