### PR TITLE
Pie 2035/api add update endpoint to attendance

### DIFF
--- a/app/controllers/api/v1/attendances_controller.rb
+++ b/app/controllers/api/v1/attendances_controller.rb
@@ -4,6 +4,8 @@ module Api
   module V1
     # API for user attendances
     class AttendancesController < Api::V1::ApiController
+      before_action :set_attendance, only: %i[update]
+
       # GET /attendances
       def index
         @attendances = policy_scope(Attendance).for_week(filter_date)
@@ -11,6 +13,14 @@ module Api
         render json: AttendanceBlueprint.render(@attendances.includes({ child_approval: :child }))
       end
 
+      def update
+        if @attendance.update(attendance_params)
+          render json: AttendanceBlueprint.render(@attendance)
+        else
+          render json: @attendance.errors, status: :unprocessable_entity
+        end
+      end
+      
       private
 
       def filter_date
@@ -19,6 +29,14 @@ module Api
         else
           Time.current.at_end_of_day
         end
+      end
+
+      def set_attendance
+        @attendance = policy_scope(Attendance).find(params[:id])
+      end
+
+      def attendance_params
+        params.require(:attendance).permit(%i[absence check_in check_out])
       end
     end
   end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -5,7 +5,7 @@ class Attendance < UuidApplicationRecord
   before_validation :round_check_in, :round_check_out
   before_validation :calc_time_in_care, if: :child_approval
   before_validation :find_or_create_service_day, if: :check_in
-  before_save :remove_absences
+  before_create :remove_absences
 
   belongs_to :child_approval
   belongs_to :service_day

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
       get 'profile', to: 'users#show'
       resources :businesses
       resources :children
-      resources :attendances, only: :index
+      resources :attendances, only: %i[index update]
       resources :service_days, only: :index
       resources :attendance_batches, only: :create
       get 'case_list_for_dashboard', to: 'users#case_list_for_dashboard'

--- a/spec/requests/api/v1/attendances_spec.rb
+++ b/spec/requests/api/v1/attendances_spec.rb
@@ -98,4 +98,74 @@ RSpec.describe 'Api::V1::Attendances', type: :request do
       end
     end
   end
+
+  describe 'PUT /api/v1/attendance/:id' do
+    include_context 'with correct api version header'
+
+    let(:attendance) { past_attendances.first }
+    let(:new_check_in) { attendance.check_in + 1.hour }
+    let(:new_check_out) { attendance.check_in + 6.hours }
+
+    context 'when logged in as a non-admin user' do
+      before do
+        sign_in logged_in_user
+      end
+
+      it 'can submit a new check_in for an attendance' do
+        check_in_params = { attendance: { check_in: new_check_in.to_s } }
+        put "/api/v1/attendances/#{attendance.id}", params: check_in_params, headers: headers
+        parsed_response = JSON.parse(response.body)
+        expect(DateTime.parse(parsed_response['check_in'])).to eq(DateTime.parse(new_check_in.to_s))
+      end
+
+      it 'can submit a new check_out for an attendance' do
+        check_out_params = { attendance: { check_out: new_check_out.to_s } }
+        put "/api/v1/attendances/#{attendance.id}", params: check_out_params, headers: headers
+        parsed_response = JSON.parse(response.body)
+        expect(DateTime.parse(parsed_response['check_out'])).to eq(DateTime.parse(new_check_out.to_s))
+      end
+
+      it 'can change an attendance to an absence' do
+        absence_params = { attendance: { absence: 'absence' } }
+        create(:schedule, child: child, effective_on: new_check_in - 2.days, weekday: new_check_in.wday)
+        put "/api/v1/attendances/#{attendance.id}", params: absence_params, headers: headers
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['absence']).to eq('absence')
+      end
+
+      it 'cannot update a different users attendance' do
+        different_user = create(:confirmed_user)
+        sign_in different_user
+        check_in_params = { attendance: { check_in: new_check_in.to_s } }
+        put "/api/v1/attendances/#{attendance.id}", params: check_in_params, headers: headers
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'when logged in as an admin user' do
+      let!(:admin_user) { create(:confirmed_user, admin: true) }
+
+      before do
+        sign_in admin_user
+      end
+
+      let(:params) do
+        {
+          attendance: {
+            check_in: new_check_in.to_s,
+            check_out: new_check_out.to_s,
+            absence: 'absence'
+          }
+        }
+      end
+
+      it 'can update check_in check_out absence for a non-admin attendance' do
+        put "/api/v1/attendances/#{attendance.id}", params: params, headers: headers
+        parsed_response = JSON.parse(response.body)
+        expect(DateTime.parse(parsed_response['check_in'])).to eq(DateTime.parse(new_check_in.to_s))
+        expect(DateTime.parse(parsed_response['check_out'])).to eq(DateTime.parse(new_check_out.to_s))
+        expect(parsed_response['absence']).to eq('absence')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
Closes #2035  It adds an update endpoint to the attendance api controller.  It does not include all the tests in the issue.  Would suggest splitting into separate issue for those tests to be written for coverage on the attendance model.
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write & run tests and linters?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally
<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
