### PR TITLE
[PIE-2086] Fixes the authorization period columns for inactive kids

### DIFF
--- a/client/src/Dashboard/DashboardTable.js
+++ b/client/src/Dashboard/DashboardTable.js
@@ -357,7 +357,9 @@ export default function DashboardTable({
             sorter: (a, b) =>
               dayjs(a.approvalEffectiveOn) - dayjs(b.approvalEffectiveOn),
             render: (text, record) =>
-              isNotApproved(record)
+              isInactive(record)
+                ? '-'
+                : isNotApproved(record)
                 ? 'unknown'
                 : `${dayjs(record.approvalEffectiveOn).format('M/D/YY')}${
                     record.approvalExpiresOn
@@ -369,13 +371,17 @@ export default function DashboardTable({
             name: 'hoursRemaining',
             sorter: (a, b) => a.hoursRemaining - b.hoursRemaining,
             render: (text, record) =>
-              `${record.hoursRemaining} (of ${record.hoursAuthorized})`
+              isInactive(record)
+                ? '-'
+                : `${record.hoursRemaining} (of ${record.hoursAuthorized})`
           },
           {
             name: 'fullDaysRemaining',
             sorter: (a, b) => a.fullDaysRemaining - b.fullDaysRemaining,
             render: (text, record) =>
-              `${record.fullDaysRemaining} (of ${record.fullDaysAuthorized})`
+              isInactive(record)
+                ? '-'
+                : `${record.fullDaysRemaining} (of ${record.fullDaysAuthorized})`
           }
         ]
       },

--- a/client/src/Dashboard/__tests__/DashboardTable.test.js
+++ b/client/src/Dashboard/__tests__/DashboardTable.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, screen, waitFor } from 'setupTests'
 import { MemoryRouter } from 'react-router-dom'
 import DashboardTable from '../DashboardTable'
+import { prettyDOM } from '@testing-library/dom'
 
 const doRender = (
   props = {
@@ -78,6 +79,28 @@ describe('<DashboardTable />', () => {
       expect(container).toHaveTextContent('Total hours remaining')
       expect(container).toHaveTextContent('Total days remaining')
       expect(container).toHaveTextContent('Actions')
+    })
+  })
+
+  it('does not render values for inactive children', async () => {
+    const { getAllByText } = doRender({
+      tableData: [
+        {
+          active: false,
+          child: {
+            childName: 'Inactive Child',
+            cNumber: 'wewewewe',
+            business: 'Fake Business'
+          },
+          key: 'inactive-child'
+        }
+      ],
+      userState: 'NE',
+      setActiveKey: () => {},
+      dateFilterValue: undefined
+    })
+    await waitFor(() => {
+      expect(getAllByText('-').length).toEqual(10)
     })
   })
 })


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Closes #2086 - this bug was introduced when we displayed auth period columns; they didn't account for inactive kids

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
- Go to dashboard and scroll to bottom to see inactive children (or mark one inactive)
- All fields should be populated with "-" including the total auth period columns