### PR TITLE
[PIE-2063] Fixes the sticky X on mobile views

### DIFF
--- a/client/src/_shared/Header.js
+++ b/client/src/_shared/Header.js
@@ -53,7 +53,10 @@ export function Header() {
             <Button
               type="link"
               className="text-lg"
-              onClick={() => history.push('/dashboard')}
+              onClick={() => {
+                history.push('/dashboard')
+                setMenuOpen(false)
+              }}
             >
               <span
                 className={
@@ -70,7 +73,10 @@ export function Header() {
             <Button
               type="link"
               className="text-lg"
-              onClick={() => history.push('/attendance')}
+              onClick={() => {
+                history.push('/attendance')
+                setMenuOpen(false)
+              }}
             >
               <span
                 className={
@@ -95,7 +101,10 @@ export function Header() {
             <Button
               type="link"
               className="text-lg"
-              onClick={() => changeLanguage('en')}
+              onClick={() => {
+                changeLanguage('en')
+                setMenuOpen(false)
+              }}
             >
               {t('english')}
             </Button>
@@ -105,7 +114,10 @@ export function Header() {
             <Button
               type="link"
               className="text-lg"
-              onClick={() => changeLanguage('es')}
+              onClick={() => {
+                changeLanguage('es')
+                setMenuOpen(false)
+              }}
             >
               {t('spanish')}
             </Button>


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Closes #2063 - the mobile menu wasn't explicitly setting the menu state to "closed" (which is what triggers the menu icon change) when clicking on a nav element, so this does it explicitly.

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
Click on the mobile menu in mobile view
Click on any item in the dropdown
The X should change back to a hamburger menu