### PR TITLE
[PIE-1377] Conditionally display COVID option

### DIFF
--- a/client/src/Attendance/Attendance.js
+++ b/client/src/Attendance/Attendance.js
@@ -96,12 +96,12 @@ export function Attendance() {
     if (errorIsPresent !== latestError.current) {
       latestError.current = errorIsPresent
       setErrors(errorIsPresent)
-      setColumns(generateColumns())
     }
+    setColumns(generateColumns(updatedDates))
     setColumnDates(updatedDates)
   }
 
-  const generateColumns = () => {
+  const generateColumns = (updatedDates = null) => {
     let cols = []
     for (let i = 0; i < 7; i++) {
       cols.push({
@@ -126,11 +126,12 @@ export function Attendance() {
           )
         },
         // eslint-disable-next-line react/display-name
-        render: (_, record) => {
+        render: (text, record, index) => {
           return (
             <AttendanceDataCell
               record={record}
               columnIndex={i}
+              columnDate={updatedDates === null ? '' : updatedDates[i]}
               updateAttendanceData={updateAttendanceData}
             />
           )

--- a/client/src/Attendance/AttendanceDataCell.js
+++ b/client/src/Attendance/AttendanceDataCell.js
@@ -7,6 +7,7 @@ import '_assets/styles/checkbox-overrides.css'
 export default function AttendanceDataCell({
   record,
   columnIndex,
+  columnDate,
   updateAttendanceData
 }) {
   const { t } = useTranslation()
@@ -21,7 +22,7 @@ export default function AttendanceDataCell({
   return (
     <div className="flex m-">
       <div className="mr-4">
-        <p className="font-proxima-nova-alt font-semibold mb-1">
+        <p className="mb-1 font-semibold font-proxima-nova-alt">
           {t('checkIn').toUpperCase()}
         </p>
         <TimePicker
@@ -41,7 +42,7 @@ export default function AttendanceDataCell({
         />
       </div>
       <div className="mr-4">
-        <p className="font-proxima-nova-alt font-semibold mb-1">
+        <p className="mb-1 font-semibold font-proxima-nova-alt">
           {t('checkOut').toUpperCase()}
         </p>
         <TimePicker
@@ -79,32 +80,35 @@ export default function AttendanceDataCell({
           />
           <span className="ml-3">{t('absent')}</span>
         </p>
-        <p className="mt-2">
-          <Checkbox
-            className="absence"
-            checked={absence === 'covid-related'}
-            disabled={
-              absence === 'absence' || checkInSelected || checkOutSelected
-            }
-            onChange={e =>
-              e.target.checked
-                ? handleChange(
-                    { absence: 'covid-related' },
-                    setAbsence('covid-related')
-                  )
-                : handleChange({}, setAbsence(null))
-            }
-          />
-          <span className="ml-3">
-            {t('absent') + ' - ' + t('covidRelated')}
-          </span>
-        </p>
+        {columnDate && new Date(columnDate) <= new Date('2021-07-31') && (
+          <p className="mt-2">
+            <Checkbox
+              className="absence"
+              checked={absence === 'covid-related'}
+              disabled={
+                absence === 'absence' || checkInSelected || checkOutSelected
+              }
+              onChange={e =>
+                e.target.checked
+                  ? handleChange(
+                      { absence: 'covid-related' },
+                      setAbsence('covid-related')
+                    )
+                  : handleChange({}, setAbsence(null))
+              }
+            />
+            <span className="ml-3">
+              {t('absent') + ' - ' + t('covidRelated')}
+            </span>
+          </p>
+        )}
       </div>
     </div>
   )
 }
 
 AttendanceDataCell.propTypes = {
+  columnDate: PropTypes.string,
   columnIndex: PropTypes.number.isRequired,
   record: PropTypes.object.isRequired,
   updateAttendanceData: PropTypes.func.isRequired

--- a/client/src/Attendance/_tests_/AttendanceDataCell.test.js
+++ b/client/src/Attendance/_tests_/AttendanceDataCell.test.js
@@ -1,11 +1,19 @@
 import React from 'react'
 import { render } from 'setupTests'
+import { MemoryRouter } from 'react-router-dom'
 import AttendanceDataCell from '../AttendanceDataCell'
 
-const doRender = (
-  props = { columnIndex: 0, record: {}, updateAttendanceData: () => {} }
-) => {
-  return render(<AttendanceDataCell {...props} />)
+const doRender = overrideProps => {
+  const defaultProps = {
+    columnIndex: 0,
+    record: {},
+    updateAttendanceData: () => {}
+  }
+  return render(
+    <MemoryRouter>
+      <AttendanceDataCell {...defaultProps} {...overrideProps} />
+    </MemoryRouter>
+  )
 }
 
 describe('<AttendanceDataCell />', () => {
@@ -14,6 +22,22 @@ describe('<AttendanceDataCell />', () => {
     expect(container).toHaveTextContent('CHECK IN')
     expect(container).toHaveTextContent('CHECK OUT')
     expect(container).toHaveTextContent('Absent')
-    expect(container).toHaveTextContent('Absent - Covid-related')
+    expect(container).not.toHaveTextContent('Absent - COVID-related')
+  })
+
+  it('displays the covid-related absence if the date is before July 31', () => {
+    const { container } = doRender({ columnDate: '2021-06-30' })
+    expect(container).toHaveTextContent('CHECK IN')
+    expect(container).toHaveTextContent('CHECK OUT')
+    expect(container).toHaveTextContent('Absent')
+    expect(container).toHaveTextContent('Absent - COVID-related')
+  })
+
+  it('does not display the covid-related absence if the date is after July 31', () => {
+    const { container } = doRender({ columnDate: '2021-10-30' })
+    expect(container).toHaveTextContent('CHECK IN')
+    expect(container).toHaveTextContent('CHECK OUT')
+    expect(container).toHaveTextContent('Absent')
+    expect(container).not.toHaveTextContent('Absent - COVID-related')
   })
 })

--- a/client/src/i18n/locales/en/index.json
+++ b/client/src/i18n/locales/en/index.json
@@ -222,7 +222,7 @@
   "checkIn": "Check in",
   "checkOut": "Check out",
   "absent": "Absent",
-  "covidRelated": "Covid-related",
+  "covidRelated": "COVID-related",
   "save": "Save",
   "validTime": "Please enter a valid time",
   "today": "Today",

--- a/client/src/i18n/locales/es/index.json
+++ b/client/src/i18n/locales/es/index.json
@@ -222,7 +222,7 @@
   "checkIn": "Entrada",
   "checkOut": "Salida",
   "absent": "Ausente",
-  "covidRelated": "Relacionado con covid",
+  "covidRelated": "Relacionado con COVID",
   "save": "Guardar",
   "validTime": "Por favor ingresa una fecha válida",
   "today": "Hoy",


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Closes #1377 

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
- visit the add attendance page
- there should only be an `absent` checkbox, not one for covid
- change the date to a date before July 31 2021
- the `covid` absence checkbox should show up
- clear the date with the `x` icon in the date picker
- the `covid` absence checkbox should disappear
- choose another date before 7/31/2021
- the `covid` absence checkbox should show up again
- choose another date after 7/31/2021 _without using the `x` icon first_
- the `covid` absence checkbox should disappear again