### PR TITLE
[PIE-2087] Only roll up numbers from active kids

### DIFF
--- a/client/src/Dashboard/Dashboard.js
+++ b/client/src/Dashboard/Dashboard.js
@@ -147,9 +147,12 @@ export function Dashboard() {
         ...data.reduce((acc, cv) => {
           return {
             ...acc,
-            earnedRevenueTotal: acc.earnedRevenueTotal + cv.earnedRevenue,
-            estimatedRevenueTotal:
-              acc.estimatedRevenueTotal + cv.estimatedRevenue,
+            earnedRevenueTotal: cv.active
+              ? acc.earnedRevenueTotal + cv.earnedRevenue
+              : acc.earnedRevenueTotal,
+            estimatedRevenueTotal: cv.active
+              ? acc.estimatedRevenueTotal + cv.estimatedRevenue
+              : acc.estimatedRevenueTotal,
             totalApprovedRevenueWithFamilyFeeTotal:
               acc.totalApprovedWithFamilyFeeTotal
           }


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Closes #2087 - we were including inactive kids in the rollup numbers, this removes them.

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
- visit the dashboard
- check the totals in estimated and earned revenue columns
- they should match the rollups at the top (with rounding)