### PR TITLE
[PIE-2088] view attendance duration

### DIFF
--- a/app/controllers/api/v1/service_days_controller.rb
+++ b/app/controllers/api/v1/service_days_controller.rb
@@ -14,7 +14,7 @@ module Api
       private
 
       def filter_date
-        params[:filter_date] ? Time.zone.parse(params[:filter_date]) : nil
+        params[:filter_date] ? Time.zone.parse(params[:filter_date]) : Time.current
       end
     end
   end

--- a/app/models/service_day.rb
+++ b/app/models/service_day.rb
@@ -5,7 +5,7 @@
 class ServiceDay < UuidApplicationRecord
   belongs_to :child
   has_many :attendances, dependent: :destroy
-  has_many :child_approvals, -> { order(total_time_in_care: :desc).distinct }, through: :attendances
+  has_many :child_approvals, -> { distinct }, through: :attendances
   # has_many :approvals, through: :child_approvals, dependent: :restrict_with_error
 
   validates :date, date_time_param: true, presence: true

--- a/app/policies/service_day_policy.rb
+++ b/app/policies/service_day_policy.rb
@@ -6,7 +6,7 @@ class ServiceDayPolicy < ApplicationPolicy
   class Scope < ApplicationScope
     def resolve
       if user.admin?
-        scope.all
+        scope.all.includes(child: :business).where(children: { businesses: { state: 'NE' } })
       else
         scope.joins(child: {
                       business: :user

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,7 +14,7 @@ class UserPolicy < ApplicationPolicy
   class Scope < ApplicationScope
     def resolve
       if user.admin?
-        scope.all
+        scope.all.includes(:businesses).where(businesses: { state: 'NE' })
       else
         scope.where(id: user.id).active
       end

--- a/client/src/AttendanceView/AttendanceView.js
+++ b/client/src/AttendanceView/AttendanceView.js
@@ -82,9 +82,9 @@ export function AttendanceView() {
                   ? checkInCheckOutTime + ', ' + checkIn + ' - ' + checkOut
                   : checkIn + ' - ' + checkOut
 
-              const hour = Math.floor(Number(attendance.time_in_care) / 3600)
+              const hour = Math.floor(Number(record.total_time_in_care) / 3600)
               const minute = Math.floor(
-                Number(attendance.time_in_care % 3600) / 60
+                Number(record.total_time_in_care % 3600) / 60
               )
               totalCareTime =
                 totalCareTime.length > 0
@@ -180,7 +180,8 @@ export function AttendanceView() {
               attendances: serviceDay.attendances.map(attendance => ({
                 ...attendance,
                 ...{ tags: serviceDay.tags }
-              }))
+              })),
+              total_time_in_care: serviceDay.total_time_in_care
             }
           })
           // merge attendances for each child

--- a/spec/policies/service_day_policy_spec.rb
+++ b/spec/policies/service_day_policy_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ServiceDayPolicy do
 
   let(:user) { create(:confirmed_user) }
   let(:non_owner) { create(:confirmed_user) }
-  let(:business) { create(:business, user: user) }
+  let(:business) { create(:business, :nebraska_ldds, user: user) }
   let(:admin) { create(:admin) }
   let(:child) { create(:child, business: business) }
   let(:child_approval) { child.child_approvals.first }

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -4,8 +4,10 @@ require 'rails_helper'
 
 RSpec.describe UserPolicy do
   let(:user) { create(:confirmed_user) }
-  let(:non_owner) { create(:confirmed_user) }
   let(:admin) { create(:admin) }
+  let(:non_owner) { create(:confirmed_user) }
+
+  before { create(:business, :nebraska_ldds, user: user) }
 
   permissions :index? do
     it 'grants access to the index for admins' do
@@ -42,9 +44,9 @@ RSpec.describe UserPolicy do
 
   describe UserPolicy::Scope do
     context 'when authenticated as an admin' do
-      it 'returns all users' do
+      it 'returns only Nebraska users' do
         users = described_class.new(admin, User).resolve
-        expect(users).to match_array([user, non_owner, admin])
+        expect(users).to match_array([user])
       end
     end
 

--- a/spec/requests/api/v1/service_days_spec.rb
+++ b/spec/requests/api/v1/service_days_spec.rb
@@ -8,7 +8,7 @@ require 'rails_helper'
 
 RSpec.describe 'Api::V1::ServiceDays', type: :request do
   let!(:logged_in_user) { create(:confirmed_user) }
-  let!(:business) { create(:business, user: logged_in_user) }
+  let!(:business) { create(:business, :nebraska_ldds, user: logged_in_user) }
   let!(:child) { create(:child, business: business) }
   let!(:child_approval) { child.child_approvals.first }
   let!(:timezone) { ActiveSupport::TimeZone.new(child.timezone) }
@@ -39,8 +39,10 @@ RSpec.describe 'Api::V1::ServiceDays', type: :request do
     ]
   end
 
-  let!(:extra_service_days) do
+  let!(:another_user_service_days) do
     build_list(:attendance, 3) do |attendance|
+      attendance.child_approval = create(:child_approval,
+                                         child: create(:child, business: create(:business, :nebraska_ldds)))
       attendance.check_in = Helpers
                             .next_attendance_day(child_approval: child_approval, date: week_start_date) +
                             3.hours
@@ -120,7 +122,7 @@ RSpec.describe 'Api::V1::ServiceDays', type: :request do
       it 'displays the service_days' do
         get '/api/v1/service_days', params: {}, headers: headers
         parsed_response = JSON.parse(response.body)
-        all_current_service_days = this_week_service_days + extra_service_days
+        all_current_service_days = this_week_service_days + another_user_service_days
 
         expect(parsed_response.collect do |x|
                  x['child_id']

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -5,8 +5,9 @@ require 'rails_helper'
 RSpec.describe 'Api::V1::Users', type: :request do
   # Do not send any emails (no confirmation emails, no password was changed emails)
   let(:user) { instance_double(User) }
-  let!(:logged_in_user) { create(:confirmed_user) }
-  let!(:other_user) { create(:confirmed_user) }
+  let!(:illinois_user) { create(:confirmed_user) }
+  let!(:nebraska_user) { create(:confirmed_user) }
+  let!(:nebraska_business) { create(:business, :nebraska_ldds, user: nebraska_user) }
   let!(:admin_user) { create(:confirmed_user, admin: true) }
 
   before do
@@ -18,7 +19,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
     include_context 'with correct api version header'
 
     context 'when logged in as a non-admin user' do
-      before { sign_in logged_in_user }
+      before { sign_in illinois_user }
 
       it 'returns only the user' do
         get '/api/v1/users', headers: headers
@@ -32,8 +33,8 @@ RSpec.describe 'Api::V1::Users', type: :request do
       it 'returns all users' do
         get '/api/v1/users', headers: headers
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response.collect { |x| x['greeting_name'] }).to include(logged_in_user.greeting_name)
-        expect(parsed_response.collect { |x| x['greeting_name'] }).to include(other_user.greeting_name)
+        expect(parsed_response.collect { |x| x['greeting_name'] }).not_to include(illinois_user.greeting_name)
+        expect(parsed_response.collect { |x| x['greeting_name'] }).to include(nebraska_user.greeting_name)
         expect(response.status).to eq(200)
         expect(response).to match_response_schema('users')
       end
@@ -43,13 +44,13 @@ RSpec.describe 'Api::V1::Users', type: :request do
   describe 'GET /api/v1/users/:id' do
     include_context 'with correct api version header'
 
-    context 'when logged in as a non-admin user' do
-      before { sign_in logged_in_user }
+    context 'when logged in as an Illinois non-admin user' do
+      before { sign_in illinois_user }
 
       it 'returns the user using their ID' do
-        get "/api/v1/users/#{logged_in_user.id}", headers: headers
+        get "/api/v1/users/#{illinois_user.id}", headers: headers
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response['greeting_name']).to eq(logged_in_user.greeting_name)
+        expect(parsed_response['greeting_name']).to eq(illinois_user.greeting_name)
         expect(response.status).to eq(200)
         expect(response).to match_response_schema('user')
       end
@@ -57,13 +58,13 @@ RSpec.describe 'Api::V1::Users', type: :request do
       it 'returns the user using /profile' do
         get '/api/v1/profile', headers: headers
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response['greeting_name']).to eq(logged_in_user.greeting_name)
+        expect(parsed_response['greeting_name']).to eq(illinois_user.greeting_name)
         expect(response.status).to eq(200)
         expect(response).to match_response_schema('user')
       end
 
       it 'does not return another user' do
-        get "/api/v1/users/#{other_user.id}", headers: headers
+        get "/api/v1/users/#{nebraska_user.id}", headers: headers
         expect(response.status).to eq(404)
       end
     end
@@ -71,11 +72,9 @@ RSpec.describe 'Api::V1::Users', type: :request do
     context 'when logged in as an admin user' do
       before { sign_in admin_user }
 
-      it 'returns the user' do
-        get "/api/v1/users/#{logged_in_user.id}", headers: headers
-        parsed_response = JSON.parse(response.body)
-        expect(parsed_response['greeting_name']).to eq(logged_in_user.greeting_name)
-        expect(response).to match_response_schema('user')
+      it 'does not return the illinois user' do
+        get "/api/v1/users/#{illinois_user.id}", headers: headers
+        expect(response.status).to eq(404)
       end
 
       it 'returns the admin user using /profile' do
@@ -86,18 +85,18 @@ RSpec.describe 'Api::V1::Users', type: :request do
         expect(response).to match_response_schema('user')
       end
 
-      it 'returns the other user' do
-        get "/api/v1/users/#{other_user.id}", headers: headers
+      it 'returns the nebraska user' do
+        get "/api/v1/users/#{nebraska_user.id}", headers: headers
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response['greeting_name']).to eq(other_user.greeting_name)
+        expect(parsed_response['greeting_name']).to eq(nebraska_user.greeting_name)
         expect(response).to match_response_schema('user')
       end
 
       # TODO: requires user policy changes
       # it 'returns the other user' do
-      #   get "/api/v1/users/#{other_user.id}", headers: headers
+      #   get "/api/v1/users/#{nebraska_user.id}", headers: headers
       #   parsed_response = JSON.parse(response.body)
-      #   expect(parsed_response['greeting_name']).to eq(other_user.greeting_name)
+      #   expect(parsed_response['greeting_name']).to eq(nebraska_user.greeting_name)
       #   expect(response).to match_response_schema('user')
       # end
     end
@@ -181,7 +180,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
       it 'returns the correct data schema' do
         get '/api/v1/case_list_for_dashboard', headers: headers
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response.collect { |user| user.dig_and_collect('businesses', 'cases') }.flatten.size).to eq(4)
+        expect(parsed_response.collect { |user| user.dig_and_collect('businesses', 'cases') }.flatten.size).to eq(2)
         expect(response.status).to eq(200)
         expect(response).to match_response_schema('nebraska_case_list_for_dashboard')
       end


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Closes #2088 - we should be using the service day's dynamically calculated total time in care when we display duration on the view attendance page.  I also changed the controller policies so that Admins only see Nebraska information (for more info see my post in Slack in #general 

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
View an attendance record with no check out
The duration should still be showing (likely will be 8 hours if that's what the schedule is, or 8 hours by default if there's no schedule and it's not an absence)