### PR TITLE
Adds a secondary sort on child full_name if scheduled amounts are the…

### DIFF
--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -32,9 +32,13 @@ class Approval < UuidApplicationRecord
   end
 
   def child_with_most_scheduled_hours(date:)
-    children.max_by do |child|
-      child.total_time_scheduled_this_month(date: date)
-    end
+    children.sort do |a, b|
+      if (b.total_time_scheduled_this_month(date: date) <=> a.total_time_scheduled_this_month(date: date)) == 0
+        a.full_name <=> b.full_name
+      else
+        b.total_time_scheduled_this_month(date: date) <=> a.total_time_scheduled_this_month(date: date)
+      end
+    end.first
   end
 end
 

--- a/spec/models/approval_spec.rb
+++ b/spec/models/approval_spec.rb
@@ -89,6 +89,13 @@ RSpec.describe Approval, type: :model do
       expect(approval.child_with_most_scheduled_hours(date: Time.current.in_time_zone(child_with_more_hours.timezone)))
         .to eq(child_with_more_hours)
     end
+
+    it 'returns the child with alphabetically if the children have the same schedules' do
+      create(:child, approvals: [approval], full_name: 'Zed Ying')
+      child_with_first_alpha = create(:child, approvals: [approval], full_name: 'Alpha Bet')
+      expect(approval.child_with_most_scheduled_hours(date: Time.current.in_time_zone(child_with_first_alpha.timezone)))
+        .to eq(child_with_first_alpha)
+    end
   end
 end
 


### PR DESCRIPTION
… same

## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Closes #2072 so the spreadsheet and the app tie-break the same way.

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
Create two children with the same schedule on the same approval.  Look at the dashboard; the child whose full_name comes first alphabetically should have the family fee assigned to them, and the other child should not.