### PR TITLE
[PIE-2191] Onboarding accepts renewals

### DIFF
--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -157,7 +157,7 @@ class Child < UuidApplicationRecord
         child: self,
         weekday: idx + 1,
         duration: 28_800, # seconds in 8 hours
-        effective_on: active_child_approval(Time.current).approval.effective_on
+        effective_on: approvals.first.effective_on
       )
     end
   end

--- a/app/services/wonderschool/necc/onboarding_case_importer.rb
+++ b/app/services/wonderschool/necc/onboarding_case_importer.rb
@@ -72,6 +72,13 @@ module Wonderschool
 
       def update_nebraska_approval_amounts
         approval_amount_params[:approval_periods].each do |period|
+          existing_approval_amount = NebraskaApprovalAmount.find_by(
+            nebraska_approval_amount_params(period).slice(
+              :effective_on, :expires_on
+            ).merge(child_approval: @child_approval)
+          )
+          existing_approval_amount.update!(nebraska_approval_amount_params(period)) && next if existing_approval_amount
+
           NebraskaApprovalAmount.find_or_create_by!(
             nebraska_approval_amount_params(period).merge(child_approval: @child_approval)
           )

--- a/spec/factories/children.rb
+++ b/spec/factories/children.rb
@@ -33,8 +33,8 @@ FactoryBot.define do
       after(:create) do |child, evaluator|
         create(:temporary_nebraska_dashboard_case, child: child) if evaluator.create_dashboard_case
         create(:nebraska_approval_amount,
-               child_approval: child.active_child_approval(evaluator.effective_date),
-               effective_on: evaluator.effective_date - 2.months,
+               child_approval: child.child_approvals.first,
+               effective_on: evaluator.effective_date,
                family_fee: 80.00)
         child.child_approvals.first.update!(authorized_weekly_hours: 20)
         child.schedules.reload

--- a/spec/services/wonderschool/necc/onboarding_case_importer_spec.rb
+++ b/spec/services/wonderschool/necc/onboarding_case_importer_spec.rb
@@ -50,12 +50,14 @@ module Wonderschool
               .from(0).to(3)
               .and change(NebraskaApprovalAmount, :count)
               .from(0).to(6)
+              .and not_raise_error
             expect { described_class.new.call }
               .to not_change(Child, :count)
               .and not_change(Business, :count)
               .and not_change(ChildApproval, :count)
               .and not_change(Approval, :count)
               .and not_change(NebraskaApprovalAmount, :count)
+              .and not_raise_error
           end
 
           it 'creates case records for the correct child with the correct data' do
@@ -172,7 +174,7 @@ module Wonderschool
             expect(stubbed_aws_s3_client).not_to have_received(:delete_object)
           end
 
-          it 'skips the child if the exact same child at the exact same business already exists' do
+          it 'skips the child if all their existing details are the same' do
             business = create(
               :business,
               user: first_user,
@@ -188,7 +190,31 @@ module Wonderschool
               expires_on: '2021-08-31',
               create_children: false
             )
-            create(:child, full_name: 'Thomas Eddleman', business: business, approvals: [approval])
+            child = create(:necc_child,
+                           full_name: 'Thomas Eddleman',
+                           business: business,
+                           date_of_birth: '2010-09-01',
+                           wonderschool_id: '37821',
+                           dhs_id: '14047907',
+                           enrolled_in_school: false,
+                           approvals: [approval])
+            child.reload.child_approvals.first.update!(
+              enrolled_in_school: false,
+              authorized_weekly_hours: 30,
+              full_days: 276,
+              hours: 1656,
+              special_needs_rate: false,
+              special_needs_hourly_rate: nil,
+              special_needs_daily_rate: nil,
+              rate_type: nil,
+              rate_id: nil
+            )
+            child.reload.nebraska_approval_amounts.first.update!(
+              effective_on: Date.parse('2020-09-01'),
+              expires_on: Date.parse('2021-08-31'),
+              family_fee: 0,
+              allocated_family_fee: 0
+            )
             expect { described_class.new.call }
               .to change(Child, :count)
               .from(1).to(5)
@@ -199,7 +225,89 @@ module Wonderschool
               .and change(Approval, :count)
               .from(1).to(3)
               .and change(NebraskaApprovalAmount, :count)
-              .from(0).to(5)
+              .from(1).to(6)
+              .and not_raise_error
+          end
+
+          it 'processes the child with new approval details if they already exist' do
+            business = create(
+              :business,
+              user: first_user,
+              name: "Rebecca's Childcare",
+              zipcode: '68845',
+              county: 'Corke',
+              license_type: 'Family Child Care Home II'.downcase.tr(' ', '_')
+            )
+            approval = create(
+              :approval,
+              case_number: '14635435',
+              effective_on: '2019-09-01',
+              expires_on: '2020-08-31',
+              create_children: false
+            )
+            create(:necc_child,
+                   full_name: 'Thomas Eddleman',
+                   business: business,
+                   date_of_birth: '2010-09-01',
+                   wonderschool_id: '37821',
+                   dhs_id: '14047907',
+                   enrolled_in_school: false,
+                   approvals: [approval],
+                   effective_date: Time.zone.parse('2019-09-01'))
+            expect { described_class.new.call }
+              .to change(Child, :count)
+              .from(1).to(5)
+              .and change(Business, :count)
+              .from(1).to(2)
+              .and change(ChildApproval, :count)
+              .from(1).to(6)
+              .and change(Approval, :count)
+              .from(1).to(4)
+              .and change(NebraskaApprovalAmount, :count)
+              .from(1).to(7)
+              .and not_raise_error
+          end
+
+          it 'updates the child with new approval details if the new approval overlaps' do
+            business = create(
+              :business,
+              user: first_user,
+              name: "Rebecca's Childcare",
+              zipcode: '68845',
+              county: 'Corke',
+              license_type: 'Family Child Care Home II'.downcase.tr(' ', '_')
+            )
+            approval = create(
+              :approval,
+              case_number: '14635435',
+              effective_on: '2020-06-01',
+              expires_on: '2021-05-31',
+              create_children: false
+            )
+            child = create(:necc_child,
+                           full_name: 'Thomas Eddleman',
+                           business: business,
+                           date_of_birth: '2010-09-01',
+                           wonderschool_id: '37821',
+                           dhs_id: '14047907',
+                           enrolled_in_school: false,
+                           approvals: [approval],
+                           effective_date: Time.zone.parse('2020-06-01'))
+            expect { described_class.new.call }
+              .to change(Child, :count)
+              .from(1).to(5)
+              .and change(Business, :count)
+              .from(1).to(2)
+              .and change(ChildApproval, :count)
+              .from(1).to(6)
+              .and change(Approval, :count)
+              .from(1).to(4)
+              .and change(NebraskaApprovalAmount, :count)
+              .from(1).to(7)
+              .and not_raise_error
+            child.reload
+            expect((child.approvals.reject { |app| app == approval }).first.expires_on).to eq(Date.parse('2021-08-31'))
+            expect(approval.reload.expires_on).to eq(Date.parse('2020-08-31'))
           end
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,3 +102,4 @@ end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change
 RSpec::Matchers.define_negated_matcher :not_include, :include
+RSpec::Matchers.define_negated_matcher :not_raise_error, :raise_error


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Fixes #2191 and unblocks #2190

The onboarding spreadsheet used to skip kids that already existed in the db; this adds logic to either add a new approval, update an existing approval, or add an updated approval and expire the old one if it overlaps.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
Run an onboarding spreadsheet with kids that already exist and new approval info, it should update them as listed in the spec expectations

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
TODO: Still have to update if the approval dates are the same.