### PR TITLE
Pie 2192/bug fix dashboard query to include last day of approval

### DIFF
--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -40,7 +40,7 @@ class Child < UuidApplicationRecord
         lambda { |date|
           joins(:approvals)
             .where(
-              'approvals.effective_on <= ? and (approvals.expires_on is null or approvals.expires_on > ?)',
+              'approvals.effective_on <= ? and (approvals.expires_on is null or approvals.expires_on >= ?)',
               date,
               date
             )

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Child, type: :model do
       expect(described_class.approved_for_date(child.approvals.first.effective_on)).to include(inactive_child)
       expect(described_class.approved_for_date(child.approvals.first.effective_on)).to include(deleted_child)
       expect(described_class.approved_for_date(child.approvals.first.effective_on - 1.day)).to eq([])
+      expect(described_class.approved_for_date(child.approvals.first.expires_on)).to include(child)
     end
 
     it 'displays inactive children but not deleted children in the not_deleted scope' do


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
#2192 This fixes a bug that will refactor with_dashboard_case query for the dashboard to include children on the last day of their approval.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write & run tests and linters?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally
<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
