### PR TITLE
Removes empty service days from response to API

### DIFF
--- a/app/controllers/api/v1/service_days_controller.rb
+++ b/app/controllers/api/v1/service_days_controller.rb
@@ -7,7 +7,7 @@ module Api
       # GET /service_days
       def index
         @service_days = policy_scope(
-          ServiceDay.includes(child: { business: :user })
+          ServiceDay.joins(:attendances).includes(child: { business: :user })
           .includes(attendances: { child_approval: :child })
         ).for_week(filter_date)
 

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -5,11 +5,12 @@ class Attendance < UuidApplicationRecord
   before_validation :round_check_in, :round_check_out
   before_validation :calc_time_in_care, if: :child_approval
   before_validation :find_or_create_service_day, on: :create, if: :check_in
-  before_save :remove_other_attendances, if: :will_save_change_to_absence?
-  before_create :remove_absences, unless: :absence
+  # after_update :remove_old_service_day, if: :saved_change_to_service_day_id?
+  after_create :remove_absences, unless: :absence
   before_update :assign_new_service_day, if: :will_save_change_to_check_in?
-  after_update :remove_old_service_day, if: :saved_change_to_service_day_id?
+  after_save_commit :remove_other_attendances, if: :saved_change_to_absence?
   after_save_commit :calculate_service_day
+  after_destroy :destroy_empty_service_day, if: :service_day_has_no_attendances
 
   belongs_to :child_approval
   belongs_to :service_day
@@ -120,12 +121,6 @@ class Attendance < UuidApplicationRecord
     other_attendances&.destroy_all
   end
 
-  def remove_old_service_day
-    previous_service_day = ServiceDay.find_by(id: service_day_id_previously_was)
-
-    previous_service_day.destroy if previous_service_day.attendances.blank?
-  end
-
   def prevent_creation_of_absence_without_schedule
     return unless absence
 
@@ -150,6 +145,14 @@ class Attendance < UuidApplicationRecord
 
   def calculate_service_day
     ServiceDayCalculatorJob.perform_later(service_day.id)
+  end
+
+  def service_day_has_no_attendances
+    service_day.attendances.empty?
+  end
+
+  def destroy_empty_service_day
+    service_day.destroy!
   end
 end
 

--- a/spec/requests/api/v1/service_days_spec.rb
+++ b/spec/requests/api/v1/service_days_spec.rb
@@ -95,6 +95,16 @@ RSpec.describe 'Api::V1::ServiceDays', type: :request do
       end
     end
 
+    context 'when a service day has no attendances' do
+      before { Attendance.all.destroy_all }
+
+      it 'does not display that attendance in the response' do
+        get '/api/v1/service_days', params: {}, headers: headers
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response).to be_empty
+      end
+    end
+
     context 'when sent without a filter date' do
       it 'displays the service_days' do
         get '/api/v1/service_days', params: {}, headers: headers


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Supports #1170 - removes empty service days from API endpoint

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->

Delete all attendances for a service day.  It should no longer show up in the endpoint returning service days.  It should be deleted.