### PR TITLE
Changes scope on approval and child to include the last day of the approval for all views that use those scopes

### DIFF
--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -20,10 +20,8 @@ class Approval < UuidApplicationRecord
   # validates :copay_frequency, inclusion: { in: COPAY_FREQUENCIES, allow_nil: true }
 
   scope :active, -> { where(active: true) }
-  scope :active_on,
-        lambda { |date|
-          where('effective_on <= ? and (expires_on is null or expires_on > ?)', date, date).order(updated_at: :desc)
-        }
+  scope :active_on, ->(date) { where(effective_on: ..date).where(expires_on: [date.., nil]).order(updated_at: :desc) }
+  # TODO: needs to change to timestamp and get sent from front-end with timestamps
 
   monetize :copay_cents, allow_nil: true
 

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -38,12 +38,7 @@ class Child < UuidApplicationRecord
   scope :active, -> { where(active: true) }
   scope :approved_for_date,
         lambda { |date|
-          joins(:approvals)
-            .where(
-              'approvals.effective_on <= ? and (approvals.expires_on is null or approvals.expires_on >= ?)',
-              date,
-              date
-            )
+          joins(:approvals).where(approvals: { effective_on: ..date }).where(approvals: { expires_on: [date.., nil] })
         }
   scope :not_deleted, -> { where(deleted_at: nil) }
   scope :nebraska, -> { joins(:business).where(business: { state: 'NE' }) }

--- a/app/models/illinois_approval_amount.rb
+++ b/app/models/illinois_approval_amount.rb
@@ -8,7 +8,8 @@ class IllinoisApprovalAmount < UuidApplicationRecord
   validates :full_days_approved_per_week, numericality: true, allow_nil: true
 
   scope :for_month,
-        lambda { |date_time = Time.current|
+        lambda { |date_time|
+          date_time ||= Time.current
           where(month: date_time.at_beginning_of_month.to_date..date_time.at_end_of_month.to_date)
         }
 end

--- a/app/models/nebraska/dashboard_case.rb
+++ b/app/models/nebraska/dashboard_case.rb
@@ -5,13 +5,9 @@ module Nebraska
   # rubocop:disable Metrics/ClassLength
   class DashboardCase
     attr_reader :absent_days,
-                :active_nebraska_approval_amount,
-                :approval,
                 :attended_days,
                 :business,
                 :child,
-                :child_approvals,
-                :child_approval,
                 :filter_date,
                 :reimbursable_month_absent_days,
                 :schedules
@@ -23,11 +19,7 @@ module Nebraska
       @absent_days = absent_days
       @business = child.business
       @schedules = child&.schedules
-      @child_approvals = child&.child_approvals&.with_approval
-      @approval = child&.approvals&.active_on(filter_date)&.first
-      @child_approval = approval.child_approvals.find_by(child: child)
       @reimbursable_month_absent_days = reimbursable_absent_service_days
-      @active_nebraska_approval_amount = child&.active_nebraska_approval_amount(filter_date)
     end
 
     def attendance_risk
@@ -217,6 +209,38 @@ module Nebraska
     end
 
     private
+
+    def child_approvals
+      Appsignal.instrument_sql(
+        'dashboard_case.child_approvals'
+      ) do
+        @child_approvals ||= child&.child_approvals&.with_approval
+      end
+    end
+
+    def approval
+      Appsignal.instrument_sql(
+        'dashboard_case.approval'
+      ) do
+        @approval ||= child&.approvals&.active_on(filter_date)&.first
+      end
+    end
+
+    def child_approval
+      Appsignal.instrument_sql(
+        'dashboard_case.child_approval'
+      ) do
+        @child_approval ||= approval&.child_approvals&.find_by(child: child)
+      end
+    end
+
+    def active_nebraska_approval_amount
+      Appsignal.instrument_sql(
+        'dashboard_case.active_nebraska_approval_amount'
+      ) do
+        @active_nebraska_approval_amount ||= child&.active_nebraska_approval_amount(filter_date)
+      end
+    end
 
     def service_days_this_month
       Appsignal.instrument_sql(

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -73,11 +73,16 @@ RSpec.describe Child, type: :model do
     end
 
     it 'only displays children approved for the requested date in the approved_for_date scope' do
-      expect(described_class.approved_for_date(child.approvals.first.effective_on)).to include(child)
-      expect(described_class.approved_for_date(child.approvals.first.effective_on)).to include(inactive_child)
-      expect(described_class.approved_for_date(child.approvals.first.effective_on)).to include(deleted_child)
-      expect(described_class.approved_for_date(child.approvals.first.effective_on - 1.day)).to eq([])
-      expect(described_class.approved_for_date(child.approvals.first.expires_on)).to include(child)
+      earliest_effective = child.approvals.first.effective_on.at_beginning_of_day
+      latest_effective = child.approvals.first.expires_on.at_end_of_day
+      expect(described_class.approved_for_date(earliest_effective)).to include(child)
+      expect(described_class.approved_for_date(earliest_effective)).to include(inactive_child)
+      expect(described_class.approved_for_date(earliest_effective)).to include(deleted_child)
+      expect(described_class.approved_for_date(earliest_effective - 1.minute)).to eq([])
+      # if it is the child's last day of their approval, it will show them
+      expect(described_class.approved_for_date(latest_effective)).to include(child)
+      # if it is after the child's last day of their approval, it will not
+      expect(described_class.approved_for_date(latest_effective + 1.minute)).to eq([])
     end
 
     it 'displays inactive children but not deleted children in the not_deleted scope' do


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

We missed a scope last time and I also did a little logic cleanup on how we request dates in scopes