### PR TITLE
Better attendance seeding

### DIFF
--- a/app/jobs/seed_demo_attendances_job.rb
+++ b/app/jobs/seed_demo_attendances_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Job to seed attendances on Demo
+class SeedDemoAttendancesJob < ApplicationJob
+  def perform(_child_id)
+    return unless ENV.fetch('HEROKU_APP_NAME', nil) == 'pie-app-demo'
+
+    DemoAttendanceSeeder.call
+  end
+end

--- a/app/services/demo_attendance_seeder.rb
+++ b/app/services/demo_attendance_seeder.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Service to seed demo attendances
+class DemoAttendanceSeeder
+  include AppsignalReporting
+
+  def call
+    generate_attendances
+  rescue StandardError => e
+    send_appsignal_error('seeding attendances', e)
+  end
+
+  private
+
+  # rubocop:disable Metrics/AbcSize
+  def generate_attendances
+    Child.all.each do |child|
+      starting_date = (last_attendance_check_out(child: child) + 1.week).at_beginning_of_week(:sunday)
+      weeks_to_populate = ((Time.current - starting_date).seconds.in_days / 7).round
+
+      Rails.logger.info { "\nChild: #{child.full_name}" }
+      Rails.logger.info { "Starting date: #{starting_date}" }
+      Rails.logger.info { "Weeks to populate: #{weeks_to_populate}\n\n" }
+
+      if weeks_to_populate.positive?
+        create_attendances(
+          child: child,
+          weeks_to_populate: weeks_to_populate,
+          starting_date: starting_date
+        )
+      end
+
+      Rails.logger.info "\n===============\n"
+    end
+  end
+
+  def create_attendances(child:, weeks_to_populate:, starting_date:)
+    catch(:stop_making_attendances) do
+      weeks_to_populate.times do |week|
+        Rails.logger.info { "Week #{week + 1} attendances:" }
+        week_start = starting_date + week.weeks
+        week_end = week_start.at_end_of_week(:sunday)
+        rand(4..6).times do |num|
+          last_attendance = num.zero? ? week_start : last_attendance_check_out(child: child)
+          break if last_attendance > week_end
+
+          check_in = Faker::Time.between(from: last_attendance, to: week_end)
+          Rails.logger.info range_string(num: num,
+                                         last_attendance: last_attendance,
+                                         week_end: week_end,
+                                         check_in: check_in)
+          active_child_approval = child.active_child_approval(check_in)
+          if check_in > Time.current || !active_child_approval
+            generate_messages(check_in: check_in, active_child_approval: active_child_approval)
+            throw :stop_making_attendances
+          end
+
+          check_out = check_in + rand(0..23).hours + rand(0..59).minutes
+          attendance = Attendance.create!(check_in: check_in,
+                                          check_out: check_out,
+                                          child_approval: active_child_approval)
+          Rails.logger.info ' ...success' if attendance
+        end
+        Rails.logger.info "\n"
+      end
+    end
+  end
+
+  def last_attendance_check_out(child:)
+    child.reload
+    last_attendance = child.attendances.presence&.order(check_in: :desc)&.first
+    last_attendance&.check_out&.in_time_zone(child.timezone) ||
+      (Time.current.in_time_zone(child.timezone) - rand(10..60).days)
+  end
+
+  def generate_messages(check_in:, active_child_approval:)
+    Rails.logger.info ' ...fail, skipping more attendances'
+    Rails.logger.info { "check_in after current time: #{check_in}" } if check_in > Time.current
+    Rails.logger.info { "no active_child_approval for #{check_in}" } unless active_child_approval
+  end
+
+  def range_string(num:, last_attendance:, week_end:, check_in:)
+    <<~STRING.squish
+      #{num + 1} |
+      Range: #{last_attendance.strftime('%Y-%m-%d %I:%M%P')} - #{week_end.strftime('%Y-%m-%d %I:%M%P')} |
+      Check-In: #{check_in.strftime('%Y-%m-%d %I:%M%P')} |
+    STRING
+  end
+  # rubocop:enable Metrics/AbcSize
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,7 +48,7 @@ module App
     logger_file = ActiveSupport::TaggedLogging.new(Log::FileLogger.new("log/#{Rails.env}.log"))
     logger_console = ActiveSupport::TaggedLogging.new(Log::ConsoleLogger.new($stdout))
     config.logger = logger_file
-    unless Rails.env.test? || Rails.env.development?
+    if ENV['RAILS_LOG_TO_STDOUT'] == 'true' && defined?(Rake) && !Rails.env.test?
       config.logger.extend(ActiveSupport::Logger.broadcast(logger_console))
     end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -114,4 +114,18 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  # Demo Environment Attendance Seeding
+
+  config.good_job.enable_cron = true
+
+  if ENV.fetch('HEROKU_APP_NAME', nil) == 'pie-app-demo'
+    config.good_job.cron = {
+      seed_demo_attendances: {
+        cron: '0 0 * * wed',
+        class: 'SeedDemoAttendancesJob',
+        description: 'Seed attendances weekly on Demo env'
+      }
+    }
+  end
 end

--- a/lib/log/console_formatter.rb
+++ b/lib/log/console_formatter.rb
@@ -7,7 +7,7 @@ module Log
       formatted_severity = format('%-5s', severity.to_s)
       formatted_time = timestamp.strftime('%Y-%m-%d %H:%M:%S.%L')
 
-      "[#{$PROCESS_ID}] #{formatted_time} #{formatted_severity}| #{msg}\n"
+      "[#{$PROCESS_ID}] #{formatted_time} #{formatted_severity} | #{msg}\n"
     end
   end
 end

--- a/lib/log/file_formatter.rb
+++ b/lib/log/file_formatter.rb
@@ -7,7 +7,7 @@ module Log
       formatted_severity = format('%-5s', severity.to_s)
       formatted_time = timestamp.strftime('%Y-%m-%d %H:%M:%S.%L')
 
-      "[#{$PROCESS_ID}] #{formatted_time} #{formatted_severity}| #{msg}\n"
+      "[#{$PROCESS_ID}] #{formatted_time} #{formatted_severity} | #{msg}\n"
     end
   end
 end

--- a/lib/tasks/attendances.rake
+++ b/lib/tasks/attendances.rake
@@ -1,42 +1,97 @@
 # frozen_string_literal: true
 
+require 'appsignal'
+
 # This is meant to simulate someone entering attendances during a month;
 # it should work multiple times a month, and it should only generate
 # attendances between the day it is run and the last attendance that was entered
 desc 'Generate attendances this month'
 task attendances: :environment do
   if Rails.application.config.allow_seeding
-    generate_attendances
+    begin
+      generate_attendances
+    rescue StandardError => e
+      send_appsignal_error('seeding attendances', e)
+    end
   else
     puts 'Error seeding attendances: this environment does not allow for seeding attendances'
   end
 end
 
 # rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/CyclomaticComplexity
-# rubocop:disable Metrics/PerceivedComplexity
 def generate_attendances
   Child.all.each do |child|
-    last_attendance_check_out ||= child.attendances.presence&.order(check_in: :desc)
-      &.last&.check_out || (Time.current - rand(1..60).days)
-    weeks_to_populate = ((Time.current - last_attendance_check_out).seconds.in_days / 7).round
-    active_child_approval = child.active_child_approval(Time.current)
+    starting_date = (last_attendance_check_out(child: child) + 1.week).at_beginning_of_week(:sunday)
+    weeks_to_populate = ((Time.current - starting_date).seconds.in_days / 7).round
 
+    puts "\nChild: #{child.full_name}"
+    puts "Starting date: #{starting_date}"
+    puts "Weeks to populate: #{weeks_to_populate}\n"
+
+    if weeks_to_populate.positive?
+      create_attendances(
+        child: child,
+        weeks_to_populate: weeks_to_populate,
+        starting_date: starting_date
+      )
+    end
+
+    puts "\n===============\n"
+  end
+end
+
+def create_attendances(child:, weeks_to_populate:, starting_date:)
+  catch(:stop_making_attendances) do
     weeks_to_populate.times do |week|
-      puts "\n\nPopulating week #{week} for #{child.full_name}"
-      rand(4..6).times do
-        start_date = last_attendance_check_out + week.weeks
-        check_in = Faker::Time.between(from: last_attendance_check_out, to: start_date.at_end_of_week(:sunday))
-        break if check_in > Time.current
+      puts "Week #{week + 1} attendances:"
+      week_start = starting_date + week.weeks
+      week_end = week_start.at_end_of_week(:sunday)
+      rand(4..6).times do |num|
+        last_attendance = num.zero? ? week_start : last_attendance_check_out(child: child)
+        break if last_attendance > week_end
+
+        check_in = Faker::Time.between(from: last_attendance, to: week_end)
+        print range_string(num: num, last_attendance: last_attendance, week_end: week_end, check_in: check_in)
+        active_child_approval = child.active_child_approval(check_in)
+        if check_in > Time.current || !active_child_approval
+          generate_messages(check_in: check_in, active_child_approval: active_child_approval)
+          throw :stop_making_attendances
+        end
 
         check_out = check_in + rand(0..23).hours + rand(0..59).minutes
-        Attendance.create!(check_in: check_in, check_out: check_out, child_approval: active_child_approval)
-        last_attendance_check_out = child.attendances.presence&.order(check_in: :desc)
-          &.last&.check_out || (Time.current - rand(1..60).days)
+        attendance = Attendance.create!(check_in: check_in, check_out: check_out, child_approval: active_child_approval)
+        puts ' ...success' if attendance
       end
+      puts "\n"
     end
   end
 end
-# rubocop:enable Metrics/PerceivedComplexity
-# rubocop:enable Metrics/CyclomaticComplexity
+
+def last_attendance_check_out(child:)
+  child.reload
+  last_attendance = child.attendances.presence&.order(check_in: :desc)&.first
+  last_attendance&.check_out&.in_time_zone(child.timezone) ||
+    (Time.current.in_time_zone(child.timezone) - rand(10..60).days)
+end
+
+def generate_messages(check_in:, active_child_approval:)
+  puts ' ...fail, skipping more attendances'
+  puts "check_in after current time: #{check_in}" if check_in > Time.current
+  puts "no active_child_approval for #{check_in}" unless active_child_approval
+end
+
+def range_string(num:, last_attendance:, week_end:, check_in:)
+  <<~STRING.squish
+    #{num + 1} |
+    Range: #{last_attendance.strftime('%Y-%m-%d %I:%M%P')} - #{week_end.strftime('%Y-%m-%d %I:%M%P')} |
+    Check-In: #{check_in.strftime('%Y-%m-%d %I:%M%P')} |
+  STRING
+end
+
+def send_appsignal_error(action, exception, identifier = nil)
+  Appsignal.send_error(exception) do |transaction|
+    transaction.set_action(action)
+    transaction.params = { time: Time.current.to_s, identifier: identifier }
+  end
+end
 # rubocop:enable Metrics/AbcSize

--- a/lib/tasks/attendances.rake
+++ b/lib/tasks/attendances.rake
@@ -1,97 +1,13 @@
 # frozen_string_literal: true
 
-require 'appsignal'
-
 # This is meant to simulate someone entering attendances during a month;
 # it should work multiple times a month, and it should only generate
 # attendances between the day it is run and the last attendance that was entered
 desc 'Generate attendances this month'
 task attendances: :environment do
   if Rails.application.config.allow_seeding
-    begin
-      generate_attendances
-    rescue StandardError => e
-      send_appsignal_error('seeding attendances', e)
-    end
+    DemoAttendanceSeeder.new.call
   else
     puts 'Error seeding attendances: this environment does not allow for seeding attendances'
   end
 end
-
-# rubocop:disable Metrics/AbcSize
-def generate_attendances
-  Child.all.each do |child|
-    starting_date = (last_attendance_check_out(child: child) + 1.week).at_beginning_of_week(:sunday)
-    weeks_to_populate = ((Time.current - starting_date).seconds.in_days / 7).round
-
-    puts "\nChild: #{child.full_name}"
-    puts "Starting date: #{starting_date}"
-    puts "Weeks to populate: #{weeks_to_populate}\n"
-
-    if weeks_to_populate.positive?
-      create_attendances(
-        child: child,
-        weeks_to_populate: weeks_to_populate,
-        starting_date: starting_date
-      )
-    end
-
-    puts "\n===============\n"
-  end
-end
-
-def create_attendances(child:, weeks_to_populate:, starting_date:)
-  catch(:stop_making_attendances) do
-    weeks_to_populate.times do |week|
-      puts "Week #{week + 1} attendances:"
-      week_start = starting_date + week.weeks
-      week_end = week_start.at_end_of_week(:sunday)
-      rand(4..6).times do |num|
-        last_attendance = num.zero? ? week_start : last_attendance_check_out(child: child)
-        break if last_attendance > week_end
-
-        check_in = Faker::Time.between(from: last_attendance, to: week_end)
-        print range_string(num: num, last_attendance: last_attendance, week_end: week_end, check_in: check_in)
-        active_child_approval = child.active_child_approval(check_in)
-        if check_in > Time.current || !active_child_approval
-          generate_messages(check_in: check_in, active_child_approval: active_child_approval)
-          throw :stop_making_attendances
-        end
-
-        check_out = check_in + rand(0..23).hours + rand(0..59).minutes
-        attendance = Attendance.create!(check_in: check_in, check_out: check_out, child_approval: active_child_approval)
-        puts ' ...success' if attendance
-      end
-      puts "\n"
-    end
-  end
-end
-
-def last_attendance_check_out(child:)
-  child.reload
-  last_attendance = child.attendances.presence&.order(check_in: :desc)&.first
-  last_attendance&.check_out&.in_time_zone(child.timezone) ||
-    (Time.current.in_time_zone(child.timezone) - rand(10..60).days)
-end
-
-def generate_messages(check_in:, active_child_approval:)
-  puts ' ...fail, skipping more attendances'
-  puts "check_in after current time: #{check_in}" if check_in > Time.current
-  puts "no active_child_approval for #{check_in}" unless active_child_approval
-end
-
-def range_string(num:, last_attendance:, week_end:, check_in:)
-  <<~STRING.squish
-    #{num + 1} |
-    Range: #{last_attendance.strftime('%Y-%m-%d %I:%M%P')} - #{week_end.strftime('%Y-%m-%d %I:%M%P')} |
-    Check-In: #{check_in.strftime('%Y-%m-%d %I:%M%P')} |
-  STRING
-end
-
-def send_appsignal_error(action, exception, identifier = nil)
-  Appsignal.send_error(exception) do |transaction|
-    transaction.set_action(action)
-    transaction.params = { time: Time.current.to_s, identifier: identifier }
-  end
-end
-# rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

This reworks the attendance seeder to avoid errors and overlapping attendances.  This also handles some of our nuisance tickets:
Fixes #1607 
Fixes #2142 