### PR TITLE
Changes the Edit Attendance Page to call to the Children endpoint

### DIFF
--- a/app/blueprints/business_blueprint.rb
+++ b/app/blueprints/business_blueprint.rb
@@ -3,9 +3,9 @@
 # Serializer for businesses
 class BusinessBlueprint < Blueprinter::Base
   identifier :id
+  field :name
 
   view :illinois_dashboard do
-    field :name
     exclude :id
     association :children, name: :cases, blueprint: ChildBlueprint, view: :illinois_dashboard do |business, options|
       business.children.not_deleted.distinct.approved_for_date(options[:filter_date])
@@ -13,7 +13,6 @@ class BusinessBlueprint < Blueprinter::Base
   end
 
   view :nebraska_dashboard do
-    field :name
     exclude :id
     # TODO: Multithreading? Pseudocode
     # field :children, name: :cases, blueprint: Nebraska::DashboardCaseBlueprint do |busines, options|

--- a/app/blueprints/child_blueprint.rb
+++ b/app/blueprints/child_blueprint.rb
@@ -10,6 +10,14 @@ class ChildBlueprint < Blueprinter::Base
   field :full_name
   field :wonderschool_id
 
+  view :cases do
+    association :business, blueprint: BusinessBlueprint
+    field :state
+    field :case_number do |child|
+      child&.approvals&.first&.case_number
+    end
+  end
+
   view :illinois_dashboard do
     field :case_number do |child, options|
       child.approvals.active_on(options[:filter_date]).first&.case_number

--- a/app/controllers/api/v1/children_controller.rb
+++ b/app/controllers/api/v1/children_controller.rb
@@ -9,9 +9,9 @@ module Api
 
       # GET /children
       def index
-        @children = policy_scope(Child)
+        @children = policy_scope(Child.includes(business: :user))
 
-        render json: @children
+        render json: ChildBlueprint.render(@children, view: :cases)
       end
 
       # GET /children/:id

--- a/client/src/Attendance/Attendance.js
+++ b/client/src/Attendance/Attendance.js
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import ellipse from '_assets/ellipse.svg'
 import { PaddedButton } from '_shared/PaddedButton'
-import { useCaseData } from '_shared/_hooks/useCaseData'
+import { useCaseAttendanceData } from '_shared/_hooks/useCaseAttendanceData'
 import { useApiResponse } from '_shared/_hooks/useApiResponse'
 import { setCaseData } from '_reducers/casesReducer'
 import { PIE_FOR_PROVIDERS_EMAIL } from '../constants'
@@ -20,12 +20,11 @@ export function Attendance() {
   const { sendGAEvent } = useGoogleAnalytics()
   const history = useHistory()
   const dispatch = useDispatch()
-  const { reduceTableData } = useCaseData()
+  const { reduceTableData } = useCaseAttendanceData()
   const { makeRequest } = useApiResponse()
-  const { cases, token, user } = useSelector(state => ({
+  const { cases, token } = useSelector(state => ({
     cases: state.cases,
-    token: state.auth.token,
-    user: state.user
+    token: state.auth.token
   }))
   const [tableData, setTableData] = useState(cases)
   const [isSuccessModalVisible, setSuccessModalVisibile] = useState(false)
@@ -279,13 +278,13 @@ export function Attendance() {
     const getCaseData = async () => {
       const response = await makeRequest({
         type: 'get',
-        url: '/api/v1/case_list_for_dashboard',
+        url: '/api/v1/children',
         headers: { Authorization: token }
       })
 
       if (response.ok) {
         const parsedResponse = await response.json()
-        const caseData = reduceTableData(parsedResponse, user)
+        const caseData = reduceTableData(parsedResponse)
         const reducedAttendanceData = reduceAttendanceData(caseData)
 
         dispatch(setCaseData(caseData))

--- a/client/src/Attendance/_tests_/Attendance.test.js
+++ b/client/src/Attendance/_tests_/Attendance.test.js
@@ -17,13 +17,11 @@ describe('<Attendance />', () => {
 
   afterEach(() => window.fetch.mockRestore())
 
-  it('makes call to case_list_for_dashboard when cases is not present', async () => {
+  it('makes call to children when cases is not present', async () => {
     doRender()
     await waitFor(() => {
       expect(window.fetch).toHaveBeenCalledTimes(1)
-      expect(window.fetch.mock.calls[0][0]).toBe(
-        '/api/v1/case_list_for_dashboard'
-      )
+      expect(window.fetch.mock.calls[0][0]).toBe('/api/v1/children')
     })
   })
 

--- a/client/src/_shared/_hooks/useCaseAttendanceData.js
+++ b/client/src/_shared/_hooks/useCaseAttendanceData.js
@@ -1,0 +1,26 @@
+export function useCaseAttendanceData() {
+  const reduceTableData = res => {
+    return res.flatMap((child, index) => {
+      return child.state === 'NE'
+        ? {
+            id: child.id ?? '',
+            key: `${index}-${child.full_name}`,
+            child: {
+              childName: child.full_name ?? '',
+              cNumber: child.case_number ?? '',
+              business: child.business.name ?? ''
+            },
+            active: child.active ?? true
+          }
+        : {
+            id: child.id ?? '',
+            key: `${index}-${child.full_name}`,
+            childName: child.full_name ?? '',
+            cNumber: child.case_number ?? '',
+            business: child.business.name ?? '',
+            active: child.active ?? true
+          }
+    })
+  }
+  return { reduceTableData }
+}

--- a/lib/tasks/prep.rake
+++ b/lib/tasks/prep.rake
@@ -6,7 +6,7 @@ task prep: :environment do
     yarn test-once && \
     bundle exec rubocop -a && \
     bundle exec rspec && \
-    bundle exec rails db:migrate:with_data && \
+    bundle exec rails db:migrate && \
     yarn cy:ci"
   end
 end

--- a/spec/blueprints/business_blueprint_spec.rb
+++ b/spec/blueprints/business_blueprint_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe BusinessBlueprint do
   let(:business) { create(:business) }
   let(:blueprint) { described_class.render(business) }
 
-  it 'only includes the ID' do
-    expect(JSON.parse(blueprint).keys).to contain_exactly('id')
+  it 'only includes the expected fields' do
+    expect(JSON.parse(blueprint).keys).to contain_exactly('id', 'name')
   end
 
   context 'when IL view is requested' do


### PR DESCRIPTION
Changes the Edit Attendance Page to call to the Children endpoint, which does not limit the list to children with active approvals.

## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

No ticket, this fixes a request from a customer directly.  However, this covers a prior ticket: #2128 

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
Ensure you have one student with no active approvals.  The student should show up on Edit Attendance, but not on the Dashboard

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
@cjhaddad the styling looked off to me when I ran it locally but my computer has been slow and buggy today, so it might have been a side effect.  Can you double-check?