### PR TITLE
Adds filter to the children controller

### DIFF
--- a/app/controllers/api/v1/children_controller.rb
+++ b/app/controllers/api/v1/children_controller.rb
@@ -9,7 +9,11 @@ module Api
 
       # GET /children
       def index
-        @children = policy_scope(Child.includes(business: :user))
+        @children = if params.keys.include?('child') && child_params[:site]
+                      policy_scope(Child.includes(business: :user).where(business: Business.find(child_params[:site])))
+                    else
+                      policy_scope(Child.includes(business: :user))
+                    end
 
         render json: ChildBlueprint.render(@children, view: :cases)
       end
@@ -59,14 +63,17 @@ module Api
       def child_params
         attributes = []
         attributes += %i[deleted_at] if current_user.admin?
-        attributes += %i[date_of_birth
-                         full_name
-                         first_name
-                         last_name
-                         business_id
-                         active
-                         last_active_date
-                         inactive_reason]
+        attributes += %i[
+          date_of_birth
+          full_name
+          first_name
+          last_name
+          business_id
+          active
+          last_active_date
+          inactive_reason
+          site
+        ]
         attributes += [{ approvals_attributes: %i[case_number copay_cents copay_frequency effective_on expires_on] }]
         params.require(:child).permit(attributes)
       end

--- a/app/controllers/api/v1/children_controller.rb
+++ b/app/controllers/api/v1/children_controller.rb
@@ -72,10 +72,9 @@ module Api
           active
           last_active_date
           inactive_reason
-          site
         ]
         attributes += [{ approvals_attributes: %i[case_number copay_cents copay_frequency effective_on expires_on] }]
-        params.require(:child).permit(attributes)
+        params.require(:child).permit(attributes, site: [])
       end
 
       def make_approval_amounts

--- a/spec/requests/api/v1/children_spec.rb
+++ b/spec/requests/api/v1/children_spec.rb
@@ -30,7 +30,20 @@ RSpec.describe 'Api::V1::Children', type: :request do
       end
 
       it 'returns the correct children when a site filter is sent' do
-        get '/api/v1/children', headers: headers, params: { child: { site: user_business.id } }
+        get '/api/v1/children', headers: headers, params: { child: { site: [user_business.id] } }
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response.collect { |x| x['full_name'] }).to include(*business_children.pluck(:full_name))
+        expect(parsed_response.collect do |x|
+                 x['full_name']
+               end).not_to include(*second_business_children.pluck(:full_name))
+        expect(parsed_response.collect do |x|
+                 x['full_name']
+               end).not_to include(*other_business_children.pluck(:full_name))
+        expect(response).to match_response_schema('children')
+      end
+
+      it 'returns the correct children when multiple sites are sent in the filter' do
+        get '/api/v1/children', headers: headers, params: { child: { site: [user_business.id, other_business.id] } }
         parsed_response = JSON.parse(response.body)
         expect(parsed_response.collect { |x| x['full_name'] }).to include(*business_children.pluck(:full_name))
         expect(parsed_response.collect do |x|
@@ -56,7 +69,7 @@ RSpec.describe 'Api::V1::Children', type: :request do
       end
 
       it 'returns the correct children when a site filter is sent' do
-        get '/api/v1/children', headers: headers, params: { child: { site: user_business.id } }
+        get '/api/v1/children', headers: headers, params: { child: { site: [user_business.id] } }
         parsed_response = JSON.parse(response.body)
         expect(parsed_response.collect { |x| x['full_name'] }).to include(*business_children.pluck(:full_name))
         expect(parsed_response.collect do |x|
@@ -65,6 +78,19 @@ RSpec.describe 'Api::V1::Children', type: :request do
         expect(parsed_response.collect do |x|
                  x['full_name']
                end).not_to include(*other_business_children.pluck(:full_name))
+        expect(response).to match_response_schema('children')
+      end
+
+      it 'returns the correct children when multiple sites are sent in the filter' do
+        get '/api/v1/children', headers: headers, params: { child: { site: [user_business.id, other_business.id] } }
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response.collect { |x| x['full_name'] }).to include(*business_children.pluck(:full_name))
+        expect(parsed_response.collect do |x|
+                 x['full_name']
+               end).not_to include(*second_business_children.pluck(:full_name))
+        expect(parsed_response.collect do |x|
+                 x['full_name']
+               end).to include(*other_business_children.pluck(:full_name))
         expect(response).to match_response_schema('children')
       end
     end

--- a/spec/requests/api/v1/children_spec.rb
+++ b/spec/requests/api/v1/children_spec.rb
@@ -5,9 +5,11 @@ require 'rails_helper'
 RSpec.describe 'Api::V1::Children', type: :request do
   let!(:logged_in_user) { create(:confirmed_user) }
   let!(:user_business) { create(:business_with_children, user: logged_in_user) }
-  let!(:user_children) { user_business.children }
-  let!(:non_user_business) { create(:business_with_children) }
-  let!(:non_user_children) { non_user_business.children }
+  let!(:second_user_business) { create(:business_with_children, user: logged_in_user) }
+  let!(:business_children) { user_business.children }
+  let!(:second_business_children) { second_user_business.children }
+  let!(:other_business) { create(:business_with_children) }
+  let!(:other_business_children) { other_business.children }
   let!(:admin_user) { create(:confirmed_user, admin: true) }
 
   describe 'GET /api/v1/children' do
@@ -19,8 +21,24 @@ RSpec.describe 'Api::V1::Children', type: :request do
       it "returns the user's children" do
         get '/api/v1/children', headers: headers
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response.collect { |x| x['full_name'] }).to include(user_children.first.full_name)
-        expect(parsed_response.collect { |x| x['full_name'] }).not_to include(non_user_children.first.full_name)
+        expect(parsed_response.collect { |x| x['full_name'] }).to include(*business_children.pluck(:full_name))
+        expect(parsed_response.collect { |x| x['full_name'] }).to include(*second_business_children.pluck(:full_name))
+        expect(parsed_response.collect do |x|
+                 x['full_name']
+               end).not_to include(*other_business_children.pluck(:full_name))
+        expect(response).to match_response_schema('children')
+      end
+
+      it 'returns the correct children when a site filter is sent' do
+        get '/api/v1/children', headers: headers, params: { child: { site: user_business.id } }
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response.collect { |x| x['full_name'] }).to include(*business_children.pluck(:full_name))
+        expect(parsed_response.collect do |x|
+                 x['full_name']
+               end).not_to include(*second_business_children.pluck(:full_name))
+        expect(parsed_response.collect do |x|
+                 x['full_name']
+               end).not_to include(*other_business_children.pluck(:full_name))
         expect(response).to match_response_schema('children')
       end
     end
@@ -31,8 +49,9 @@ RSpec.describe 'Api::V1::Children', type: :request do
       it "returns all users' children" do
         get '/api/v1/children', headers: headers
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response.collect { |x| x['full_name'] }).to include(user_children.first.full_name)
-        expect(parsed_response.collect { |x| x['full_name'] }).to include(non_user_children.first.full_name)
+        expect(parsed_response.collect { |x| x['full_name'] }).to include(*business_children.pluck(:full_name))
+        expect(parsed_response.collect { |x| x['full_name'] }).to include(*second_business_children.pluck(:full_name))
+        expect(parsed_response.collect { |x| x['full_name'] }).to include(*other_business_children.pluck(:full_name))
         expect(response).to match_response_schema('children')
       end
     end
@@ -45,14 +64,14 @@ RSpec.describe 'Api::V1::Children', type: :request do
       before { sign_in logged_in_user }
 
       it "returns the user's child" do
-        get "/api/v1/children/#{user_children.first.id}", headers: headers
+        get "/api/v1/children/#{business_children.first.id}", headers: headers
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response['full_name']).to eq(user_children.first.full_name)
+        expect(parsed_response['full_name']).to eq(business_children.first.full_name)
         expect(response).to match_response_schema('child')
       end
 
       it 'does not return a child for another user' do
-        get "/api/v1/children/#{non_user_children.first.id}", headers: headers
+        get "/api/v1/children/#{other_business_children.first.id}", headers: headers
         expect(response.status).to eq(404)
       end
     end
@@ -61,16 +80,16 @@ RSpec.describe 'Api::V1::Children', type: :request do
       before { sign_in admin_user }
 
       it "returns the user's child" do
-        get "/api/v1/children/#{user_children.first.id}", headers: headers
+        get "/api/v1/children/#{business_children.first.id}", headers: headers
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response['full_name']).to eq(user_children.first.full_name)
+        expect(parsed_response['full_name']).to eq(business_children.first.full_name)
         expect(response).to match_response_schema('child')
       end
 
       it 'returns a child for another user' do
-        get "/api/v1/children/#{non_user_children.first.id}", headers: headers
+        get "/api/v1/children/#{other_business_children.first.id}", headers: headers
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response['full_name']).to eq(non_user_children.first.full_name)
+        expect(parsed_response['full_name']).to eq(other_business_children.first.full_name)
         expect(response).to match_response_schema('child')
       end
     end
@@ -242,15 +261,15 @@ RSpec.describe 'Api::V1::Children', type: :request do
       before { sign_in logged_in_user }
 
       it "updates the user's child" do
-        put "/api/v1/children/#{user_children.first.id}", params: params, headers: headers
+        put "/api/v1/children/#{business_children.first.id}", params: params, headers: headers
         parsed_response = JSON.parse(response.body)
         expect(parsed_response['full_name']).to eq('Padma Patil')
-        expect(user_children.first.reload.full_name).to eq('Padma Patil')
+        expect(business_children.first.reload.full_name).to eq('Padma Patil')
         expect(response).to match_response_schema('child')
       end
 
       it 'does not update a child for another user' do
-        put "/api/v1/children/#{non_user_children.first.id}", params: params, headers: headers
+        put "/api/v1/children/#{other_business_children.first.id}", params: params, headers: headers
         expect(response.status).to eq(404)
       end
 
@@ -260,7 +279,7 @@ RSpec.describe 'Api::V1::Children', type: :request do
             date_of_birth: 'Not a date'
           }
         }
-        put "/api/v1/children/#{user_children.first.id}", params: params, headers: headers
+        put "/api/v1/children/#{business_children.first.id}", params: params, headers: headers
         expect(response.status).to eq(422)
       end
     end
@@ -269,18 +288,18 @@ RSpec.describe 'Api::V1::Children', type: :request do
       before { sign_in admin_user }
 
       it "updates the user's child" do
-        put "/api/v1/children/#{user_children.first.id}", params: params, headers: headers
+        put "/api/v1/children/#{business_children.first.id}", params: params, headers: headers
         parsed_response = JSON.parse(response.body)
         expect(parsed_response['full_name']).to eq('Padma Patil')
-        expect(user_children.first.reload.full_name).to eq('Padma Patil')
+        expect(business_children.first.reload.full_name).to eq('Padma Patil')
         expect(response).to match_response_schema('child')
       end
 
       it 'updates a child for another user' do
-        put "/api/v1/children/#{non_user_children.first.id}", params: params, headers: headers
+        put "/api/v1/children/#{other_business_children.first.id}", params: params, headers: headers
         parsed_response = JSON.parse(response.body)
         expect(parsed_response['full_name']).to eq('Padma Patil')
-        expect(non_user_children.first.reload.full_name).to eq('Padma Patil')
+        expect(other_business_children.first.reload.full_name).to eq('Padma Patil')
         expect(response).to match_response_schema('child')
       end
     end
@@ -293,9 +312,9 @@ RSpec.describe 'Api::V1::Children', type: :request do
       before { sign_in logged_in_user }
 
       it "soft-deletes the user's child" do
-        delete "/api/v1/children/#{user_children.first.id}", headers: headers
+        delete "/api/v1/children/#{business_children.first.id}", headers: headers
         expect(response.status).to eq(204)
-        expect(user_children.first.reload.deleted_at).to eq(Time.current.to_date)
+        expect(business_children.first.reload.deleted_at).to eq(Time.current.to_date)
       end
     end
 
@@ -303,9 +322,9 @@ RSpec.describe 'Api::V1::Children', type: :request do
       before { sign_in admin_user }
 
       it "soft-deletes the user's child" do
-        delete "/api/v1/children/#{user_children.first.id}", headers: headers
+        delete "/api/v1/children/#{business_children.first.id}", headers: headers
         expect(response.status).to eq(204)
-        expect(user_children.first.reload.deleted_at).to eq(Time.current.to_date)
+        expect(business_children.first.reload.deleted_at).to eq(Time.current.to_date)
       end
     end
   end

--- a/spec/requests/api/v1/children_spec.rb
+++ b/spec/requests/api/v1/children_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe 'Api::V1::Children', type: :request do
         expect(parsed_response.collect { |x| x['full_name'] }).to include(*other_business_children.pluck(:full_name))
         expect(response).to match_response_schema('children')
       end
+
+      it 'returns the correct children when a site filter is sent' do
+        get '/api/v1/children', headers: headers, params: { child: { site: user_business.id } }
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response.collect { |x| x['full_name'] }).to include(*business_children.pluck(:full_name))
+        expect(parsed_response.collect do |x|
+                 x['full_name']
+               end).not_to include(*second_business_children.pluck(:full_name))
+        expect(parsed_response.collect do |x|
+                 x['full_name']
+               end).not_to include(*other_business_children.pluck(:full_name))
+        expect(response).to match_response_schema('children')
+      end
     end
   end
 

--- a/spec/requests/api/v1/children_spec.rb
+++ b/spec/requests/api/v1/children_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe 'Api::V1::Children', type: :request do
   let!(:logged_in_user) { create(:confirmed_user) }
   let!(:user_business) { create(:business_with_children, user: logged_in_user) }
@@ -368,3 +369,4 @@ RSpec.describe 'Api::V1::Children', type: :request do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Backend work for #2017 - does what it says on the tin

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
Authenticate as an admin user and hit the `GET /children` endpoint with no params, you should get back all the kids.  Hit the endpoint again with the body:
```
{
  "child": {
    "site": [
      <business ID string>
  }
}
```
You should see only the kids in that business.

If you send two strings, you should see the kids for both businesses; this array will accept any number of IDs
```
{
  "child": {
    "site": [
      <business ID string>,
      <business ID string>
  }
}
```

If you log in as a non-admin user, send one of your business IDs, you should see the kids for that business.  Send another user's business IDs, and you shouldn't see those kids.