### PR TITLE
[PIE 1794] API buildout: Add PUT endpoint for user profile info

### DIFF
--- a/app/blueprints/business_blueprint.rb
+++ b/app/blueprints/business_blueprint.rb
@@ -21,12 +21,12 @@ class BusinessBlueprint < Blueprinter::Base
   end
 
   view :profile do
+    field :id
     field :name
     field :license_type
     field :zipcode
     field :county
     field :qris_rating
     field :accredited
-    exclude :id
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,8 +4,8 @@ module Api
   module V1
     # API for application users
     class UsersController < Api::V1::ApiController
-      before_action :set_user, only: %i[show]
-      before_action :authorize_user, only: %i[show]
+      before_action :set_user, only: %i[show update]
+      before_action :authorize_user, only: %i[show update]
 
       # GET /users
       def index
@@ -21,6 +21,15 @@ module Api
           @user,
           view: :profile
         )
+      end
+
+      # PUT /profile or PUT /users/:id
+      def update
+        if @user.update(user_params)
+          render json: UserBlueprint.render(@user, view: :profile)
+        else
+          render json: @user.errors, status: :unprocessable_entity
+        end
       end
 
       # GET /case_list_for_dashboard
@@ -64,6 +73,13 @@ module Api
           view: :illinois_dashboard,
           filter_date: filter_date
         )
+      end
+
+      def user_params
+        attributes = []
+        attributes += %i[id full_name email language phone_number]
+        attributes += [{ businesses_attributes: %i[id accredited county license_type name qris_rating zipcode] }]
+        params.require(:user).permit(attributes)
       end
     end
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,7 +14,7 @@ class UserPolicy < ApplicationPolicy
   class Scope < ApplicationScope
     def resolve
       if user.admin?
-        scope.all.includes(:businesses).where(businesses: { state: 'NE' })
+        scope.all
       else
         scope.where(id: user.id).active
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,8 +24,9 @@ Rails.application.routes.draw do
 
   scope module: :api, defaults: { format: :json }, path: 'api' do
     scope module: :v1, constraints: ApiConstraint.new(version: 1, default: true), path: 'v1' do
-      resources :users, only: %i[index show]
+      resources :users, only: %i[index show update]
       get 'profile', to: 'users#show'
+      put 'profile', to: 'users#update'
       resources :businesses
       resources :children
       resources :attendances, only: %i[index update]
@@ -63,7 +64,10 @@ end
 #                        letter_opener_web        /letter_opener                                                                                    LetterOpenerWeb::Engine
 #                                    users GET    /api/v1/users(.:format)                                                                           api/v1/users#index {:format=>:json}
 #                                     user GET    /api/v1/users/:id(.:format)                                                                       api/v1/users#show {:format=>:json}
+#                                          PATCH  /api/v1/users/:id(.:format)                                                                       api/v1/users#update {:format=>:json}
+#                                          PUT    /api/v1/users/:id(.:format)                                                                       api/v1/users#update {:format=>:json}
 #                                  profile GET    /api/v1/profile(.:format)                                                                         api/v1/users#show {:format=>:json}
+#                                          PUT    /api/v1/profile(.:format)                                                                         api/v1/users#update {:format=>:json}
 #                               businesses GET    /api/v1/businesses(.:format)                                                                      api/v1/businesses#index {:format=>:json}
 #                                          POST   /api/v1/businesses(.:format)                                                                      api/v1/businesses#create {:format=>:json}
 #                                 business GET    /api/v1/businesses/:id(.:format)                                                                  api/v1/businesses#show {:format=>:json}

--- a/spec/blueprints/business_blueprint_spec.rb
+++ b/spec/blueprints/business_blueprint_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe BusinessBlueprint do
 
     it 'includes the required fields' do
       expect(JSON.parse(blueprint).keys).to contain_exactly(
+        'id',
         'name',
         'license_type',
         'zipcode',

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe UserPolicy do
 
   describe UserPolicy::Scope do
     context 'when authenticated as an admin' do
-      it 'returns only Nebraska users' do
+      it 'returns all users' do
         users = described_class.new(admin, User).resolve
-        expect(users).to match_array([user])
+        expect(users).to match_array([user, admin, non_owner])
       end
     end
 

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
       it 'returns all users' do
         get '/api/v1/users', headers: headers
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response.collect { |x| x['greeting_name'] }).not_to include(illinois_user.greeting_name)
+        expect(parsed_response.collect { |x| x['greeting_name'] }).to include(illinois_user.greeting_name)
         expect(parsed_response.collect { |x| x['greeting_name'] }).to include(nebraska_user.greeting_name)
         expect(response.status).to eq(200)
         expect(response).to match_response_schema('users')
@@ -75,7 +75,10 @@ RSpec.describe 'Api::V1::Users', type: :request do
 
       it 'does not return the illinois user' do
         get "/api/v1/users/#{illinois_user.id}", headers: headers
-        expect(response.status).to eq(404)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['greeting_name']).to eq(illinois_user.greeting_name)
+        expect(response.status).to eq(200)
+        expect(response).to match_response_schema('user')
       end
 
       it 'returns the admin user using /profile' do
@@ -219,7 +222,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
       it 'returns the correct data schema' do
         get '/api/v1/case_list_for_dashboard', headers: headers
         parsed_response = JSON.parse(response.body)
-        expect(parsed_response.collect { |user| user.dig_and_collect('businesses', 'cases') }.flatten.size).to eq(2)
+        expect(parsed_response.collect { |user| user.dig_and_collect('businesses', 'cases') }.flatten.size).to eq(4)
         expect(response.status).to eq(200)
         expect(response).to match_response_schema('nebraska_case_list_for_dashboard')
       end


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
closes #1794 

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?

## 🧳 Steps to test
Test the `/profile` and `/users/:id` endpoints in Postman (under Authenticated Routes > Profile).
Both user and associated businesses should update. Only permitted fields will be allowed.
