### PR TITLE
Changes the params to URL params

### DIFF
--- a/app/controllers/api/v1/children_controller.rb
+++ b/app/controllers/api/v1/children_controller.rb
@@ -52,9 +52,9 @@ module Api
       end
 
       def set_children
-        @children = if params[:child].present? && child_params[:site]
+        @children = if params[:business].present?
                       policy_scope(Child.includes(business: :user).where(
-                        business: Business.find(child_params[:site])
+                        business: Business.find(params[:business].split(','))
                       ).order(:last_name))
                     else
                       policy_scope(Child.includes(business: :user).order(:last_name))
@@ -78,7 +78,7 @@ module Api
           inactive_reason
         ]
         attributes += [{ approvals_attributes: %i[case_number copay_cents copay_frequency effective_on expires_on] }]
-        params.require(:child).permit(attributes, site: [])
+        params.require(:child).permit(attributes, business: [])
       end
 
       def make_approval_amounts

--- a/spec/requests/api/v1/children_spec.rb
+++ b/spec/requests/api/v1/children_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe 'Api::V1::Children', type: :request do
         expect(response).to match_response_schema('children')
       end
 
-      it 'returns the correct children when a site filter is sent' do
-        get '/api/v1/children', headers: headers, params: { child: { site: [user_business.id] } }
+      it 'returns the correct children when a business filter is sent' do
+        get '/api/v1/children', headers: headers, params: { business: [user_business.id] }
         parsed_response = JSON.parse(response.body)
         expect(parsed_response.collect do |x|
                  "#{x['first_name']} #{x['last_name']}"
@@ -55,8 +55,8 @@ RSpec.describe 'Api::V1::Children', type: :request do
         expect(response).to match_response_schema('children')
       end
 
-      it 'returns the correct children when multiple sites are sent in the filter' do
-        get '/api/v1/children', headers: headers, params: { child: { site: [user_business.id, other_business.id] } }
+      it 'returns the correct children when multiple businesses are sent in the filter' do
+        get '/api/v1/children', headers: headers, params: { business: [user_business.id, other_business.id] }
         parsed_response = JSON.parse(response.body)
         expect(parsed_response.collect do |x|
                  "#{x['first_name']} #{x['last_name']}"
@@ -97,8 +97,8 @@ RSpec.describe 'Api::V1::Children', type: :request do
         expect(response).to match_response_schema('children')
       end
 
-      it 'returns the correct children when a site filter is sent' do
-        get '/api/v1/children', headers: headers, params: { child: { site: [user_business.id] } }
+      it 'returns the correct children when a business filter is sent' do
+        get '/api/v1/children', headers: headers, params: { business: [user_business.id] }
         parsed_response = JSON.parse(response.body)
         expect(parsed_response.collect do |x|
                  "#{x['first_name']} #{x['last_name']}"
@@ -114,8 +114,8 @@ RSpec.describe 'Api::V1::Children', type: :request do
         expect(response).to match_response_schema('children')
       end
 
-      it 'returns the correct children when multiple sites are sent in the filter' do
-        get '/api/v1/children', headers: headers, params: { child: { site: [user_business.id, other_business.id] } }
+      it 'returns the correct children when multiple businesses are sent in the filter' do
+        get '/api/v1/children', headers: headers, params: { business: [user_business.id, other_business.id] }
         parsed_response = JSON.parse(response.body)
         expect(parsed_response.collect do |x|
                  "#{x['first_name']} #{x['last_name']}"


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

This fixes #2470 so business IDs can be sent to the children parameter to filter by business.  It also changes the param name to better represent the data model.  Now requests can be sent as follows:

```
/api/v1/children?business=2183e7ec-06e1-4f58-bbcc-bcfc6b4b6ff6,ff9edb05-afa1-4ded-ad95-0c39403d6560
```

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
Get a list of business IDs from your db.  Hit the endpoint:
```
/api/v1/children?business=2183e7ec-06e1-4f58-bbcc-bcfc6b4b6ff6,ff9edb05-afa1-4ded-ad95-0c39403d6560
```
should return all the kids belonging to two businesses
```
/api/v1/children?business=2183e7ec-06e1-4f58-bbcc-bcfc6b4b6ff6
```
should return only kids belonging to the first business
```
/api/v1/children
```
should return all kids in the user's scope

## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
