### PR TITLE
[PIE-2627] Adds business param query

### DIFF
--- a/app/policies/service_day_policy.rb
+++ b/app/policies/service_day_policy.rb
@@ -6,11 +6,13 @@ class ServiceDayPolicy < ApplicationPolicy
   class Scope < ApplicationScope
     def resolve
       if user.admin?
-        scope.all.includes(child: :business).where(children: { businesses: { state: 'NE' } })
+        scope.all.joins(child: :business).where(children: { businesses: { state: 'NE' } })
       else
-        scope.joins(child: {
-                      business: :user
-                    }).where(children: { businesses: { user: user } })
+        scope.joins(
+          child: {
+            business: :user
+          }
+        ).where(children: { businesses: { user: user } })
       end
     end
   end


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Adds business param query to support #2378 

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
Hit the /service_days end point with a business=[] param, supports multiple ids