### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-*             @katelovescode
 client/       @cjhaddad
 spec/cypress/ @cjhaddad


### PR DESCRIPTION
Removes my github account from codeowners so I don't get automatically pinged for dependency update reviews, etc.