### PR TITLE
fix: [P4P-2945] Adding name attribute to select components from antd.…

### DIFF
--- a/client/src/Signup/Signup.js
+++ b/client/src/Signup/Signup.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Alert, Form, Input, Select, Radio, Checkbox } from 'antd'
+import { Alert, Form, Input, Radio, Checkbox } from 'antd'
 import { useHistory } from 'react-router-dom'
 import { PaddedButton } from '_shared/PaddedButton'
 import { Link } from 'react-router-dom'
@@ -16,8 +16,9 @@ import ConfirmationSent from './ConfirmationSent'
 import StateDropdown from './StateDropdown'
 import SignupQuestion from './SignupQuestion'
 import useFreshsales from '_shared/_hooks/useFreshsales'
+import Select from '_shared/_components/Select/Select'
+import { Option } from '_shared/_components/Select/Select'
 
-const { Option } = Select
 const { TextArea } = Input
 
 /**
@@ -155,9 +156,10 @@ export function Signup() {
               {t('phoneType')}
             </label>
             <Select
+              id="phoneType"
+              name="phoneType"
               value={user.phoneType}
               style={{ width: '30%', borderRight: '0', textAlign: 'left' }}
-              name="phoneType"
               data-cy="phoneType"
               placeholder={t('phoneTypePlaceholder')}
               onChange={value => {
@@ -523,6 +525,16 @@ export function Signup() {
             </a>
           </p>
         </div>
+        <Form.Item style={{ display: 'none' }}>
+          <Input name="lifecycleStage" type="lifecycle stage" value="Sign-up" />
+        </Form.Item>
+        <Form.Item style={{ display: 'none' }}>
+          <Input
+            name="lifecycleStage"
+            type="status"
+            value="Completed sign-up form"
+          />
+        </Form.Item>
       </Form>
     </main>
   )

--- a/client/src/Signup/StateDropdown.js
+++ b/client/src/Signup/StateDropdown.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Select } from 'antd'
 import { useTranslation } from 'react-i18next'
-
-const { Option } = Select
+import Select, { Option } from '_shared/_components/Select/Select'
 
 function StateDropdown({ onChange }) {
   const { t } = useTranslation()
@@ -67,6 +65,7 @@ function StateDropdown({ onChange }) {
       onChange={onChange}
       data-cy="state"
       name="state"
+      id="state-name"
     >
       {stateOptions.map(state => (
         <Option key={state.value} value={state.value} data-cy={state.value}>

--- a/client/src/_shared/ActionLink.js
+++ b/client/src/_shared/ActionLink.js
@@ -18,7 +18,7 @@ export function ActionLink({ onClick, text = '', classes = '', children }) {
 
 ActionLink.propTypes = {
   onClick: PropTypes.func.isRequired,
-  text: PropTypes.string,
+  text: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   children: PropTypes.node,
   classes: PropTypes.string
 }

--- a/client/src/_shared/_components/Select/Select.js
+++ b/client/src/_shared/_components/Select/Select.js
@@ -1,0 +1,27 @@
+import React, { useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { Select as AntDSelect } from 'antd'
+import addNameAttributeToSelectById from '_utils/htmlHelper'
+
+const Select = ({ id, name, children, ...extraProps }) => {
+  useEffect(() => {
+    addNameAttributeToSelectById(id, name)
+  }, [id, name])
+
+  return (
+    <AntDSelect id={id} {...extraProps}>
+      {children}
+    </AntDSelect>
+  )
+}
+
+Select.propTypes = {
+  id: PropTypes.string,
+  name: PropTypes.string,
+  extraProps: PropTypes.any,
+  children: PropTypes.any
+}
+
+export default Select
+const { Option } = AntDSelect
+export { Option }

--- a/client/src/_shared/_components/Select/__tests__/Select.test.js
+++ b/client/src/_shared/_components/Select/__tests__/Select.test.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { render, screen } from 'setupTests'
+import Select from '../Select'
+import { Option } from '../Select'
+
+const doRender = () => {
+  return render(
+    <Select id="test" name="test-name" data-testid="test">
+      <Option>Test value</Option>
+    </Select>
+  )
+}
+
+describe('<Select />', () => {
+  it('assigns a name attribute to the input select component', async () => {
+    doRender()
+    const input = screen.getAllByRole('combobox')[0]
+
+    expect(input.getAttribute('name')).toEqual('test-name')
+  })
+})

--- a/client/src/_utils/htmlHelper.js
+++ b/client/src/_utils/htmlHelper.js
@@ -1,0 +1,7 @@
+const NAME = 'name'
+const addNameAttributeToSelectById = (elementId, name) => {
+  const element = document.getElementById(elementId)
+  element.setAttribute(NAME, name)
+}
+
+export default addNameAttributeToSelectById


### PR DESCRIPTION
… Fixing broken props definition for action link

## 💅🏼 What issue does this fix?
https://github.com/pieforproviders/pieforproviders/issues/2945

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write & run tests and linters?
* [x] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [x] Does your PR contain any required translations?
* [x] Are your primary keys UUIDs on any new tables?

## 🧳 Steps to test
Go to the signup form and make sure that state and phone type dropdowns print their corresponding name attributes in the HTML tag.

