### PR TITLE
Print messages to users when uploading attendances

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,6 +94,7 @@ end
 #  full_name                    :string           not null
 #  get_from_pie                 :text
 #  greeting_name                :string
+#  heard_about                  :string
 #  language                     :string           not null
 #  last_sign_in_at              :datetime
 #  last_sign_in_ip              :inet

--- a/app/services/attendance_csv_importer.rb
+++ b/app/services/attendance_csv_importer.rb
@@ -45,6 +45,7 @@ class AttendanceCsvImporter
     return unless (@start_date..@end_date).cover?(@row['check_in'].in_time_zone(@child.timezone).at_beginning_of_day)
 
     create_attendance
+    print_successful_message if should_print_message?
   rescue StandardError => e
     # rubocop:disable Rails/Output
     pp "Error on child #{@child.inspect}. error => #{e.inspect}"
@@ -127,5 +128,15 @@ class AttendanceCsvImporter
     # rubocop:enable Rails/Output
 
     raise NoSuchBusiness
+  end
+
+  def print_successful_message
+    # rubocop:disable Rails/Output
+    pp "DHS ID: #{@row['dhs_id']} has been successfully processed"
+    # rubocop:enable Rails/Output
+  end
+
+  def should_print_message?
+    !Rails.env.test?
   end
 end

--- a/app/services/attendance_csv_importer.rb
+++ b/app/services/attendance_csv_importer.rb
@@ -46,6 +46,10 @@ class AttendanceCsvImporter
 
     create_attendance
   rescue StandardError => e
+    # rubocop:disable Rails/Output
+    pp "Error on child #{@child.inspect}. error => #{e.inspect}"
+    # rubocop:enable Rails/Output
+
     send_appsignal_error(
       action: 'self-serve-attendance-csv-importer',
       exception: e,
@@ -93,23 +97,35 @@ class AttendanceCsvImporter
     found_child = @business.children.find_by(dhs_id: @row['dhs_id']) || @business.children.find_by(
       first_name: @row['first_name'], last_name: @row['last_name']
     )
+
     found_child.presence || log_missing_child
   end
 
   def log_missing_child
+    message = "Business: #{@business.id} - child record for attendance " \
+              "not found (dhs_id: #{@row['dhs_id']}, check_in: #{@row['check_in']}, " \
+              "check_out: #{@row['check_out']}, absence: #{@row['absence']}); skipping"
     Rails.logger.tagged('attendance import') do
-      message = "Business: #{@business.id} - child record for attendance " \
-                "not found (dhs_id: #{@row['dhs_id']}, check_in: #{@row['check_in']}, " \
-                "check_out: #{@row['check_out']}, absence: #{@row['absence']}); skipping"
       Rails.logger.info message
     end
+
+    # rubocop:disable Rails/Output
+    pp message
+    # rubocop:enable Rails/Output
+
     raise NoSuchChild
   end
 
   def log_missing_business
+    message = "Business #{@file_name.split('-').first} not found; skipping"
     Rails.logger.tagged('attendance import') do
-      Rails.logger.info "Business #{@file_name.split('-').first} not found; skipping"
+      Rails.logger.info message
     end
+
+    # rubocop:disable Rails/Output
+    pp message
+    # rubocop:enable Rails/Output
+
     raise NoSuchBusiness
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -69,6 +69,7 @@ end
 #  full_name                    :string           not null
 #  get_from_pie                 :text
 #  greeting_name                :string
+#  heard_about                  :string
 #  language                     :string           not null
 #  last_sign_in_at              :datetime
 #  last_sign_in_ip              :inet

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -145,6 +145,7 @@ end
 #  full_name                    :string           not null
 #  get_from_pie                 :text
 #  greeting_name                :string
+#  heard_about                  :string
 #  language                     :string           not null
 #  last_sign_in_at              :datetime
 #  last_sign_in_ip              :inet


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Print message to user who is running the rake task directly on a console.
## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write & run tests and linters?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Are your primary keys UUIDs on any new tables?

## 🧵 Steps to set up locally
<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->
Upload an attendance file to the s3 bucket
run: rails attendance_csv_importer
## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
Upload an attendance file
Upload an attendance file to the s3 bucket
run: heroku run bundle exec rails attendance_csv_importer -a pie-staging