### PR TITLE
fix: [PIE-3196] [Fabian] Using regular input rather than masked input…

### DIFF
--- a/client/src/Signup/Signup.js
+++ b/client/src/Signup/Signup.js
@@ -3,7 +3,6 @@ import { Alert, Form, Input, Radio, Checkbox } from 'antd'
 import { useHistory } from 'react-router-dom'
 import { PaddedButton } from '_shared/PaddedButton'
 import { Link } from 'react-router-dom'
-import MaskedInput from 'antd-mask-input'
 import { useTranslation } from 'react-i18next'
 import { useApiResponse } from '_shared/_hooks/useApiResponse'
 import { useGoogleAnalytics } from '_shared/_hooks/useGoogleAnalytics'
@@ -187,7 +186,7 @@ export function Signup() {
               style={{ width: '70%', marginBottom: 0 }}
               rules={[
                 {
-                  pattern: /^\d{3}-\d{3}-\d{4}$/,
+                  pattern: /^\d{10}$/,
                   message: t('phoneNumberInvalid')
                 },
                 {
@@ -202,14 +201,10 @@ export function Signup() {
                 `${t('phone')} ${t(validationErrors.phone_number[0].error)}`
               }
             >
-              <MaskedInput
-                mask="111-111-1111"
-                placeholder="___-___-____"
-                size="10"
-                className="h-8"
+              <Input
+                value={user.phoneNumber}
                 data-cy="phoneNumber"
                 name="phoneNumber"
-                value={user.phoneNumber}
                 onChange={event =>
                   setUser({ ...user, phoneNumber: event.target.value })
                 }


### PR DESCRIPTION
… which has conflicts on latest versions

## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Sign up form could not process new users because of an incompatibility issue with MaskedInput component. This problem started to occur when we updated antd and antd-mask-input libraries.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [ ] Did you write & run tests and linters?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Migrations
* [ ] Dependencies

## 🧵 Steps to set up locally
<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
Try submitting a new form.
## 🕯 Caveats, concerns
<!-- Anything you'd like to bring to the attention of reviewers -->
