### PR TITLE
feat: [PIE-3209] [Fabian] Saving wonderschool_id only when field is not numeric

### DIFF
--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -71,6 +71,8 @@ class Child < UuidApplicationRecord
   delegate :state, to: :user
   delegate :timezone, to: :user
 
+  before_save :validate_wonderschool_id
+
   def age(date = Time.current)
     years_since_birth = date.year - date_of_birth.year
     birthday_passed = date_of_birth.month <= date.month || date_of_birth.day <= date.day
@@ -182,6 +184,10 @@ class Child < UuidApplicationRecord
 
   def associate_rate
     RateAssociatorJob.perform_later(id)
+  end
+
+  def validate_wonderschool_id
+    self.wonderschool_id = wonderschool_id.to_i.to_s == wonderschool_id ? wonderschool_id : nil
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/spec/factories/children.rb
+++ b/spec/factories/children.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
         effective_date { 6.months.ago }
       end
       business { create(:business, :nebraska_ldds) }
-      wonderschool_id { SecureRandom.uuid }
+      wonderschool_id { SecureRandom.random_number(10**6).to_s.rjust(6, '0') }
       approvals { [create(:approval, create_children: false, effective_on: effective_date)] }
 
       after(:create) do |child, evaluator|

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -298,6 +298,34 @@ RSpec.describe Child do
       end
     end
   end
+
+  describe 'before_action' do
+    it 'allows to save only numeric values to its wonderschool_id attribute' do
+      wonderschool_id = SecureRandom.random_number(10**6).to_s.rjust(6, '0')
+      child_with_wonderschool_id = create(:child, wonderschool_id: wonderschool_id)
+      expect(child_with_wonderschool_id.wonderschool_id).to eq(wonderschool_id)
+
+      child_with_wonderschool_id.wonderschool_id = 'not present'
+      child_with_wonderschool_id.save
+      child_with_wonderschool_id.reload
+      expect(child_with_wonderschool_id.wonderschool_id).to be_nil
+
+      child_with_wonderschool_id.wonderschool_id = wonderschool_id
+      child_with_wonderschool_id.save
+      child_with_wonderschool_id.reload
+      expect(child_with_wonderschool_id.wonderschool_id).to eq(wonderschool_id)
+
+      child_with_wonderschool_id.wonderschool_id = ''
+      child_with_wonderschool_id.save
+      child_with_wonderschool_id.reload
+      expect(child_with_wonderschool_id.wonderschool_id).to be_nil
+
+      child_with_wonderschool_id.wonderschool_id = 'N/A'
+      child_with_wonderschool_id.save
+      child_with_wonderschool_id.reload
+      expect(child_with_wonderschool_id.wonderschool_id).to be_nil
+    end
+  end
 end
 # == Schema Information
 #


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Corresponds to [ticket 3209](https://github.com/pieforproviders/pieforproviders/issues/3209). wonderschool_id should only accept numeric values. Any other value should fallback to null.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write & run tests and linters?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Are your primary keys UUIDs on any new tables?

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
When uploading an onboarding file, try using random strings on the wonderschool_id field. It should not complain, but it won{t save anything there.
