### PR TITLE
manually delete first attendance

### DIFF
--- a/client/src/AttendanceView/AttendanceView.js
+++ b/client/src/AttendanceView/AttendanceView.js
@@ -117,7 +117,9 @@ export function AttendanceView() {
             // TODO Refactor: no attendance should be saveable with a check-out and no check-in
             if (index === 0) {
               setModalButtonDisabled(
-                !(mergedValue.check_in || update.absenceType)
+                mergedValue.check_in &&
+                  !mergedValue.check_out &&
+                  !update.absenceType
               )
             }
 

--- a/client/src/_shared/AttendanceDataCell.js
+++ b/client/src/_shared/AttendanceDataCell.js
@@ -166,68 +166,32 @@ export default function AttendanceDataCell({
                   })
           })}
         </div>
-        <div>
-          <p>
-            <Checkbox
-              className="absence"
-              checked={absence === 'absence'}
-              disabled={
-                /* disable this box if the absence is already marked as covid-related, or if check-in/out is selected */
-                absence === 'covid-related' ||
-                checkInSelected ||
-                checkOutSelected
-              }
-              onChange={e => {
-                e.target.checked
-                  ? handleChange({
-                      update: { absenceType: 'absence' },
-                      callback: () => {
-                        setShowSecondCheckIn(false)
-                        setAbsence('absence')
-                      }
-                    })
-                  : handleChange({
-                      update: { absenceType: null },
-                      callback: () => {
-                        setAbsence(null)
-                      }
-                    })
-              }}
-            />
-            <span className="ml-3">{t('absent')}</span>
-          </p>
-          {
-            /* show COVID checkbox before 2021-07-31 */
-            columnDate && new Date(columnDate) <= new Date('2021-07-31') && (
-              <p className="mt-2">
-                <Checkbox
-                  className="absence"
-                  checked={absence === 'covid-related'}
-                  disabled={
-                    /* disable this box if the absence is already marked as a regular absence, or if check-in/out is selected */
-                    absence === 'absence' || checkInSelected || checkOutSelected
-                  }
-                  onChange={e =>
-                    e.target.checked
-                      ? handleChange({
-                          update: { absenceType: 'covid-related' },
-                          callback: () => {
-                            setShowSecondCheckIn(false)
-                            setAbsence('covid-related')
-                          }
-                        })
-                      : handleChange({
-                          update: { absenceType: null },
-                          callback: setAbsence(null)
-                        })
-                  }
-                />
-                <span className="ml-3">
-                  {t('absent') + ' - ' + t('covidRelated')}
-                </span>
-              </p>
-            )
-          }
+        <div className="flex items-center">
+          <Button
+            type="text"
+            className="flex -ml-4 font-semibold font-proxima-nova"
+            onClick={() => {
+              handleChange({
+                update: {
+                  absenceType: null,
+                  check_in: null,
+                  check_out: null
+                },
+                callback: () =>
+                  setTimePickerValues(prevValues => ({
+                    ...prevValues,
+                    ...{
+                      firstCheckIn: null,
+                      firstCheckOut: null
+                    }
+                  })),
+                secondCheckIn: false
+              })
+            }}
+          >
+            <CloseOutlined className="font-semibold text-red1" />
+            <p className="ml-1 text-red1">{t('removeCheckInTime')}</p>
+          </Button>
         </div>
       </div>
       <div className="flex flex-row mt-4">
@@ -353,6 +317,67 @@ export default function AttendanceDataCell({
             </Button>
           </div>
         )}
+      </div>
+      <div className="flex flex-row mt-4">
+        <p>
+          <Checkbox
+            className="absence"
+            checked={absence === 'absence'}
+            disabled={
+              /* disable this box if the absence is already marked as covid-related, or if check-in/out is selected */
+              absence === 'covid-related' || checkInSelected || checkOutSelected
+            }
+            onChange={e => {
+              e.target.checked
+                ? handleChange({
+                    update: { absenceType: 'absence' },
+                    callback: () => {
+                      setShowSecondCheckIn(false)
+                      setAbsence('absence')
+                    }
+                  })
+                : handleChange({
+                    update: { absenceType: null },
+                    callback: () => {
+                      setAbsence(null)
+                    }
+                  })
+            }}
+          />
+          <span className="ml-3">{t('absent')}</span>
+        </p>
+        {
+          /* show COVID checkbox before 2021-07-31 */
+          columnDate && new Date(columnDate) <= new Date('2021-07-31') && (
+            <p className="mt-2">
+              <Checkbox
+                className="absence"
+                checked={absence === 'covid-related'}
+                disabled={
+                  /* disable this box if the absence is already marked as a regular absence, or if check-in/out is selected */
+                  absence === 'absence' || checkInSelected || checkOutSelected
+                }
+                onChange={e =>
+                  e.target.checked
+                    ? handleChange({
+                        update: { absenceType: 'covid-related' },
+                        callback: () => {
+                          setShowSecondCheckIn(false)
+                          setAbsence('covid-related')
+                        }
+                      })
+                    : handleChange({
+                        update: { absenceType: null },
+                        callback: setAbsence(null)
+                      })
+                }
+              />
+              <span className="ml-3">
+                {t('absent') + ' - ' + t('covidRelated')}
+              </span>
+            </p>
+          )
+        }
       </div>
     </div>
   )

--- a/client/src/_shared/AttendanceDataCell.js
+++ b/client/src/_shared/AttendanceDataCell.js
@@ -169,7 +169,7 @@ export default function AttendanceDataCell({
         <div className="flex items-center">
           <Button
             type="text"
-            className="flex -ml-4 font-semibold font-proxima-nova"
+            className="flex -ml-4 mt-6 font-semibold font-proxima-nova"
             onClick={() => {
               handleChange({
                 update: {
@@ -278,7 +278,7 @@ export default function AttendanceDataCell({
             <div className="flex items-center">
               <Button
                 type="text"
-                className="flex -ml-4 font-semibold font-proxima-nova"
+                className="flex -ml-4 mt-6 font-semibold font-proxima-nova"
                 onClick={() => {
                   handleChange({
                     update: {

--- a/client/src/_shared/AttendanceDataCell.js
+++ b/client/src/_shared/AttendanceDataCell.js
@@ -167,31 +167,34 @@ export default function AttendanceDataCell({
           })}
         </div>
         <div className="flex items-center">
-          <Button
-            type="text"
-            className="flex -ml-4 mt-6 font-semibold font-proxima-nova"
-            onClick={() => {
-              handleChange({
-                update: {
-                  absenceType: null,
-                  check_in: null,
-                  check_out: null
-                },
-                callback: () =>
-                  setTimePickerValues(prevValues => ({
-                    ...prevValues,
-                    ...{
-                      firstCheckIn: null,
-                      firstCheckOut: null
-                    }
-                  })),
-                secondCheckIn: false
-              })
-            }}
-          >
-            <CloseOutlined className="font-semibold text-red1" />
-            <p className="ml-1 text-red1">{t('removeCheckInTime')}</p>
-          </Button>
+          {(timePickerValues.firstCheckIn ||
+            timePickerValues.firstCheckOut) && (
+            <Button
+              type="text"
+              className="flex -ml-4 mt-6 font-semibold font-proxima-nova"
+              onClick={() => {
+                handleChange({
+                  update: {
+                    absenceType: null,
+                    check_in: null,
+                    check_out: null
+                  },
+                  callback: () =>
+                    setTimePickerValues(prevValues => ({
+                      ...prevValues,
+                      ...{
+                        firstCheckIn: null,
+                        firstCheckOut: null
+                      }
+                    })),
+                  secondCheckIn: false
+                })
+              }}
+            >
+              <CloseOutlined className="font-semibold text-red1" />
+              <p className="ml-1 text-red1">{t('removeCheckInTime')}</p>
+            </Button>
+          )}
         </div>
       </div>
       <div className="flex flex-row mt-4">

--- a/client/src/_shared/__tests__/AttendanceDataCell.test.js
+++ b/client/src/_shared/__tests__/AttendanceDataCell.test.js
@@ -26,6 +26,20 @@ describe('<AttendanceDataCell />', () => {
     expect(container).toHaveTextContent('Add check-in time')
   })
 
+  it('shows first Remove check-in button when check in/out is selected', () => {
+    const { container } = doRender({
+      defaultValues: {
+        attendances: [
+          {
+            check_in: '2023-05-15 14:00:00 UTC',
+            check_out: '2023-05-15 15:00:00 UTC'
+          }
+        ]
+      }
+    })
+    expect(container).toHaveTextContent('Remove check-in')
+  })
+
   it('adds a second set of attendance inputs', () => {
     doRender()
     let addCheckInButton = screen.getByText(/Add check-in time/)


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
#3190 This would add a remove check in button for the first  check in/out picker. This will only show up if there is a check in or check out time selected.  It will allow you to remove the check-in/out and delete an attendance on the attendance page like you can with a second attendance on the same day.

## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [x] Did you write & run tests and linters?
* [x] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Are your primary keys UUIDs on any new tables?

## 🛷 Deployment
<!-- What do we need to know to deploy this code out? -->
* [ ] Migrations
* [ ] Dependencies


## 🕯 Caveats, concerns
