### PR TITLE
fix: [PIE-3299] [Fabian] Changing URL for reset password link

### DIFF
--- a/app/mailers/devise_custom_mailer.rb
+++ b/app/mailers/devise_custom_mailer.rb
@@ -44,7 +44,7 @@ class DeviseCustomMailer < Devise::Mailer
   end
 
   def password_update_path(token)
-    "#{domain}/password/update?reset_password_token=#{token}"
+    "https://#{domain}/password/update?reset_password_token=#{token}"
   end
 
   def domain


### PR DESCRIPTION
## 💅🏼 What issue does this fix?
<!-- Which Github Issue is this related to?  Summarize the work in a sentence or two.  To automatically link your PR to its issue, use keywords like "closes #714" -->
<!-- Githubs docs on linking issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Users not able to submit new password after going through reset password flow.
## 🍂 Before You Submit
<!-- Check steps as necessary - this list is a reminder -->
* [X] Did you write & run tests and linters?
* [ ] Did you run Google Lighthouse and/or WebAIM (Wave) on UI components in your PR?
* [ ] Does your PR contain any required translations?
* [ ] Are your primary keys UUIDs on any new tables?

## 🧵 Steps to set up locally
<!--
A list of things you need to change to get the code going
* Any new environment variables
* Any build steps
* Any docker changes
* Any migrations or tasks that need to run manually
-->
This cannot be tested locally. It always worked there.

## 🧳 Steps to test
<!-- Outline how to confirm the changes. Very similar to the **Steps to Reproduce** from tickets -->
Try resetting a password for a any user in staging, demo or production.
